### PR TITLE
Adding GetPasswordPolicyTypeAsync method to return the password policy of the user pool

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -156,7 +156,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Queries Cognito and returns the CognitoUser with the corresponding userID
         /// </summary>
         /// <param name="userID">The userID of the corresponding user</param>
-        ///<returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
         public async Task<CognitoUser> FindByIdAsync(string userID)
         {
             if (string.IsNullOrEmpty(userID))


### PR DESCRIPTION
Adding GetPasswordPolicyTypeAsync method to return the password policy of the user pool
*Issue #, if available:*
N/A

*Description of changes:*
This changes returns the user pool password policy. This will be used to validate password before user registration.

This change also includes a small doc change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
