### PR TITLE
Using a cryptographic random number generator

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoDeviceHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoDeviceHelper.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Amazon.Extensions.CognitoAuthentication.Util
@@ -62,11 +63,12 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
         public static void GenerateDeviceSaltAndVerifier(string deviceGroupKey, string deviceKey, string password)
         {
             byte[] deviceKeyHash = GetDeviceKeyHash(deviceGroupKey, deviceKey, password);
-            Random random = new Random();
 
             Salt = new byte[16];
-            random.NextBytes(Salt);
-
+            using (var cryptoRandom = RandomNumberGenerator.Create())
+            {
+                cryptoRandom.GetBytes(Salt);
+            }
             Verifier = CalculateVerifier(Salt, deviceKeyHash);
         }
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3206

*Description of changes:* Using a cryptographic random number (System.Security.Cryptography.RandomNumberGenerator) generator instead of the Random class 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
