### PR TITLE
Allowing optional attributes when responding to change password challenge

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>1.0.2</PackageVersion>
+    <PackageVersion>1.0.3</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -176,10 +176,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
+        public Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
         {
-            var result = await RespondToNewPasswordRequiredAsync(newPasswordRequest, null).ConfigureAwait(false);
-            return result;
+            return RespondToNewPasswordRequiredAsync(newPasswordRequest, null);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -202,9 +202,9 @@ namespace Amazon.Extensions.CognitoAuthentication
 
             if (requiredAttributes != null)
             {
-                foreach (var attributeName in requiredAttributes.Keys)
+                foreach (KeyValuePair<string, string> attribute in requiredAttributes)
                 {
-                    challengeResponses.Add(attributeName, requiredAttributes[attributeName]);
+                    challengeResponses.Add(attribute.Key, attribute.Value);
                 }
             }
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -173,12 +173,26 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// password required authentication challenge using an asynchronous call
         /// </summary>
         /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
+        /// parameters to respond to the current SMS MFA authentication challenge</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
+        {
+            var result = await RespondToNewPasswordRequiredAsync(newPasswordRequest, null).ConfigureAwait(false);
+            return result;
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToNewPasswordRequiredRequest object to respond to the current new 
+        /// password required authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
         /// <param name="requiredAttributes">Optional dictionnary of attributes that may be required by the user pool
         /// Each attribute key must be prefixed by "userAttributes."
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes = null)
+        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
         {
             var challengeResponses = new Dictionary<string, string>()
             {

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -173,18 +173,31 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// password required authentication challenge using an asynchronous call
         /// </summary>
         /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
+        /// <param name="requiredAttributes">Optional dictionnary of attributes that may be required by the user pool
+        /// Each attribute key must be prefixed by "userAttributes."
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
+        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes = null)
         {
+            var challengeResponses = new Dictionary<string, string>()
+            {
+                { CognitoConstants.ChlgParamNewPassword, newPasswordRequest.NewPassword},
+                { CognitoConstants.ChlgParamUsername, Username }
+            };
+
+            if (requiredAttributes != null)
+            {
+                foreach (var attributeName in requiredAttributes.Keys)
+                {
+                    challengeResponses.Add(attributeName, requiredAttributes[attributeName]);
+                }
+            }
+
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {
-                ChallengeResponses = new Dictionary<string, string>
-                    {
-                        { CognitoConstants.ChlgParamNewPassword, newPasswordRequest.NewPassword},
-                        { CognitoConstants.ChlgParamUsername, Username }
-                    },
+                
+                ChallengeResponses = challengeResponses,
                 Session = newPasswordRequest.SessionID,
                 ClientId = ClientID,
                 ChallengeName = ChallengeNameType.NEW_PASSWORD_REQUIRED


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3350

*Description of changes:*
 Fixes https://github.com/aws/aws-sdk-net/issues/1129

There was a missing parameter when resetting password. 

Tested with my personal account, fixes the bug


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
