### PR TITLE
Device SRP Authentication

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,16 @@
 *Issue #, if available:*
+ 
+ Issue 44,
+ Issue 28,
+ Issue 10
 
 *Description of changes:*
+Fixes "Key already in dictionary" exception in StartWithSrpAuthAsync.
+	Key is already being added earlier in authentication process, so to maintain existing logic, we simply use an indexer
+	to 'add' the device key to the challenge auth response (Deeper fix could look at why it is being added twice)
 
+Adds necessary logic to handle Device SRP authentication after a successful User SRP_AUTH and PASSWORD_VERIFIER.
+	Within StartWithSrpAuthAsync, if the verifierResponse from the SrpPasswordVerifierAuthRequest is null, we attempt to respond
+	to a "DEVICE_SRP_AUTH" challenge, as well as a "DEVICE_PASSWORD_VERIFIER" challenge. 
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -79,8 +79,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// The password for the corresponding CognitoUser.
         /// </summary>
         public string Password { get; set; }
+        /// <summary>
+        /// The password for the device associated with the corresponding CognitoUser 
+        /// </summary>
         public string DevicePass { get; set; }
+        /// <summary>
+        /// The device password verifier for the device associated with the corresponding CognitoUser
+        /// </summary>
         public string DeviceVerifier { get; set; }
+        /// <summary>
+        /// The Device Key Group for the device associated with the corresponding CognitoUser
+        /// </summary>
         public string DeviceGroupKey { get; set; }
     }
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -79,6 +79,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// The password for the corresponding CognitoUser.
         /// </summary>
         public string Password { get; set; }
+        public string DevicePass { get; set; }
+        public string DeviceVerifier { get; set; }
+        public string DeviceGroupKey { get; set; }
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -95,6 +95,8 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         private string PoolName { get; set; }
 
+       
+
         /// <summary>
         /// Creates an instance of CognitoUser
         /// </summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -95,8 +95,6 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         private string PoolName { get; set; }
 
-       
-
         /// <summary>
         /// Creates an instance of CognitoUser
         /// </summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -58,7 +58,6 @@ namespace Amazon.Extensions.CognitoAuthentication
                 challengeRequest.ChallengeResponses[CognitoConstants.ChlgParamDeviceKey] = Device.DeviceKey;
             }
 
-
             RespondToAuthChallengeResponse verifierResponse =
                 await Provider.RespondToAuthChallengeAsync(challengeRequest).ConfigureAwait(false);
 
@@ -240,11 +239,27 @@ namespace Amazon.Extensions.CognitoAuthentication
                 new Dictionary<string, string>(authResponse.ResponseMetadata.Metadata));
         }
 
+        /// <summary>
+        /// Generates a DeviceSecretVerifierConfigType object for a device associated with a CognitoUser for SRP Authentication
+        /// </summary>
+        /// <param name="deviceGroupKey">The DeviceKey Group for the associated CognitoDevice</param>
+        /// <param name="deviceKey">The DeviceKey for the associated CognitoDevice</param>
+        /// <param name="devicePass">The random password for the associated CognitoDevice</param>
+        /// <returns></returns>
         public DeviceSecretVerifierConfigType GenerateDeviceVerifier(string deviceGroupKey, string deviceKey, string devicePass)
         {
             return AuthenticationHelper.GenerateDeviceVerifier(deviceGroupKey, deviceKey, devicePass);
         }
 
+        /// <summary>
+        /// Sends a confirmation request to Cognito for a new CognitoDevice
+        /// </summary>
+        /// <param name="accessToken">The user pool access token for from the InitiateAuth or other challenge response</param>
+        /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
+        /// <param name="deviceName">The friendly name to be associated with the corresponding CognitoDevice</param>
+        /// <param name="passwordVerifier">The password verifier generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
+        /// <param name="salt">The salt generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
+        /// <returns></returns>
         public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt)
         {
             var request = new ConfirmDeviceRequest
@@ -262,6 +277,13 @@ namespace Amazon.Extensions.CognitoAuthentication
             return await Provider.ConfirmDeviceAsync(request);
         }
 
+        /// <summary>
+        /// Updates the remembered status for a given CognitoDevice
+        /// </summary>
+        /// <param name="accessToken">The user pool access token for from the InitiateAuth or other challenge response</param>
+        /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
+        /// <param name="deviceRememberedStatus">The device remembered status for the associated CognitoDevice</param>
+        /// <returns></returns>
         public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus)
         {
             var request = new UpdateDeviceStatusRequest

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -92,6 +92,12 @@ namespace Amazon.Extensions.CognitoAuthentication
                 new Dictionary<string, string>(verifierResponse.ResponseMetadata.Metadata));
         }
 
+        /// <summary>
+        /// Internal method which responds to the DEVICE_SRP_AUTH challenge in SRP authentication
+        /// </summary>
+        /// <param name="challenge">The response from the PASSWORD_VERIFIER challenge</param>
+        /// <param name="tupleAa">Tuple of BigIntegers containing the A,a pair for the SRP protocol flow</param>
+        /// <returns></returns>
         private RespondToAuthChallengeRequest CreateDeviceSrpAuthRequest(RespondToAuthChallengeResponse challenge, Tuple<BigInteger, BigInteger> tupleAa)
         {
             


### PR DESCRIPTION
*Issue #, if available:*

 Issue 44,
 Issue 28,
 Issue 10

*Description of changes:*
Fixes "Key already in dictionary" exception in StartWithSrpAuthAsync.
	Key is already being added earlier in authentication process, so to maintain existing logic, we simply use an indexer
	to 'add' the device key to the challenge auth response (Deeper fix could look at why it is being added twice)

Adds necessary logic to handle Device SRP authentication after a successful User SRP_AUTH and PASSWORD_VERIFIER.
	Within StartWithSrpAuthAsync, if the verifierResponse from the SrpPasswordVerifierAuthRequest is null, we attempt to respond
	to a "DEVICE_SRP_AUTH" challenge, as well as a "DEVICE_PASSWORD_VERIFIER" challenge. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.