### PR TITLE
Virtual methods for CognitoUser

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -163,7 +163,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="confirmationCode">Confirmation code sent to user via email or SMS</param>
         /// <param name="forcedAliasCreation">Boolean specifying whether forced alias creation is desired</param>
-        public Task ConfirmSignUpAsync(string confirmationCode, bool forcedAliasCreation)
+        public virtual Task ConfirmSignUpAsync(string confirmationCode, bool forcedAliasCreation)
         {
             ConfirmSignUpRequest confirmRequest = CreateConfirmSignUpRequest(confirmationCode, forcedAliasCreation);
 
@@ -174,7 +174,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Request to resend registration confirmation code for a user using an asynchronous call
         /// </summary>
         /// <returns>Returns the delivery details for the confirmation code request</returns>
-        public Task ResendConfirmationCodeAsync()
+        public virtual Task ResendConfirmationCodeAsync()
         {
             ResendConfirmationCodeRequest resendRequest = CreateResendConfirmationCodeRequest();
 
@@ -185,7 +185,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Allows the user to reset their password using an asynchronous call. Should be used in 
         /// conjunction with the ConfirmPasswordAsync method 
         /// </summary>
-        public Task ForgotPasswordAsync()
+        public virtual Task ForgotPasswordAsync()
         {
             ForgotPasswordRequest forgotPassRequest = CreateForgotPasswordRequest();
 
@@ -198,7 +198,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="confirmationCode">The confirmation code sent to the suer</param>
         /// <param name="newPassword">The new desired password for the user</param>
-        public Task ConfirmForgotPasswordAsync(string confirmationCode, string newPassword)
+        public virtual Task ConfirmForgotPasswordAsync(string confirmationCode, string newPassword)
         {
             ConfirmForgotPasswordRequest confirmResetPassRequest =
                 CreateConfirmPasswordRequest(confirmationCode, newPassword);
@@ -212,7 +212,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="oldPass">The user's old password</param>
         /// <param name="newPass">The desired new password</param>
-        public Task ChangePasswordAsync(string oldPass, string newPass)
+        public virtual Task ChangePasswordAsync(string oldPass, string newPass)
         {
             ChangePasswordRequest changePassRequest = CreateChangePasswordRequest(oldPass, newPass);
 
@@ -223,7 +223,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Gets the details for the current user using an asynchronous call
         /// </summary>
         /// <returns>Returns a tuple containing the user attributes and settings, in that order</returns>
-        public Task<GetUserResponse> GetUserDetailsAsync()
+        public virtual Task<GetUserResponse> GetUserDetailsAsync()
         {
             EnsureUserAuthenticated();
 
@@ -242,7 +242,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="medium">Name of the attribute the verification code is being sent to.
         /// Should be either email or phone_number.</param>
         /// <returns>Returns the delivery details for the attribute verification code request</returns>
-        public Task GetAttributeVerificationCodeAsync(string medium)
+        public virtual Task GetAttributeVerificationCodeAsync(string medium)
         {
             GetUserAttributeVerificationCodeRequest getAttributeCodeRequest =
                     CreateGetUserAttributeVerificationCodeRequest(medium);
@@ -253,7 +253,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// Sign-out from all devices associated with this user using an asynchronous call
         /// </summary>
-        public Task GlobalSignOutAsync()
+        public virtual Task GlobalSignOutAsync()
         {
             EnsureUserAuthenticated();
 
@@ -269,7 +269,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// Deletes the current user using an asynchronous call
         /// </summary>
-        public Task DeleteUserAsync()
+        public virtual Task DeleteUserAsync()
         {
             EnsureUserAuthenticated();
 
@@ -286,7 +286,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="attributeName">Attribute to be verified. Should either be email or phone_number</param>
         /// <param name="verificationCode">The verification code for the attribute being verified</param>
-        public Task VerifyAttributeAsync(string attributeName, string verificationCode)
+        public virtual Task VerifyAttributeAsync(string attributeName, string verificationCode)
         {
             VerifyUserAttributeRequest verifyUserAttributeRequest =
                 CreateVerifyUserAttributeRequest(attributeName, verificationCode);
@@ -299,7 +299,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="attributes">The attributes to be updated</param>
-        public async Task UpdateAttributesAsync(IDictionary<string, string> attributes)
+        public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes)
         {
             UpdateUserAttributesRequest updateUserAttributesRequest =
                 CreateUpdateUserAttributesRequest(attributes);
@@ -318,7 +318,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// an asynchronous call
         /// </summary>
         /// <param name="attributeNamesToDelete">List of attributes to delete</param>
-        public async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
+        public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
         {
             DeleteUserAttributesRequest deleteUserAttributesRequest =
                 CreateDeleteUserAttributesRequest(attributeNamesToDelete);
@@ -340,7 +340,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="userSettings">Dictionary for the user MFA settings of the form [attribute, delivery medium]</param>
-        public async Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
+        public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
         {
             SetUserSettingsRequest setUserSettingsRequest = CreateSetUserSettingsRequest(userSettings);
 
@@ -359,7 +359,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="limit">Maxmimum number of devices to be returned in this call</param>
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <returns>Returns a list of CognitoDevices associated with this user</returns>
-        public async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
+        public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
         {
             ListDevicesRequest listDevicesRequest = CreateListDevicesRequest(limit, paginationToken);
             ListDevicesResponse listDevicesReponse = await Provider.ListDevicesAsync(listDevicesRequest).ConfigureAwait(false);

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -34,7 +34,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for SRP authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
+        public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
         {
             if (srpRequest == null || string.IsNullOrEmpty(srpRequest.Password))
             {
@@ -77,7 +77,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for custom authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
+        public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
         {
             InitiateAuthRequest authRequest = new InitiateAuthRequest()
             {
@@ -107,7 +107,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current custom authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
+        public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
         {
             RespondToAuthChallengeRequest request = new RespondToAuthChallengeRequest()
             {
@@ -137,7 +137,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
+        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
         {
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {
@@ -176,7 +176,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
+        public virtual Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
         {
             return RespondToNewPasswordRequiredAsync(newPasswordRequest, null);
         }
@@ -191,7 +191,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
+        public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
         {
             var challengeResponses = new Dictionary<string, string>()
             {
@@ -240,7 +240,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the refresh token authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
+        public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
         {
             InitiateAuthRequest initiateAuthRequest = CreateRefreshTokenAuthRequest(refreshTokenRequest.AuthFlowType);
 
@@ -263,7 +263,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the ADMIN_NO_SRP_AUTH authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
+        public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
         {
             AdminInitiateAuthRequest initiateAuthRequest = CreateAdminAuthRequest(adminAuthRequest);
 


### PR DESCRIPTION
*Issue #, if available:
https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/151
*Description of changes:*
Mock testing `CognitoUser` using [Moq](https://github.com/moq/moq4) fails because it needs virtual methods to create a proxy with [[1](https://github.com/moq/moq4/issues/212)]. 
![image](https://user-images.githubusercontent.com/17341777/76905669-32009880-68c4-11ea-8347-8e1276f8e8bd.png)
Currently the workaround is to write a subclass to wrap around the CognitoUser class as follows
```csharp
public class CustomCognitoUser : CognitoUser
    {
        public CustomCognitoUser(string userID, string clientID, CognitoUserPool pool, IAmazonCognitoIdentityProvider provider, string? clientSecret = null, string? status = null, string? username = null, Dictionary<string, string>? attributes = null) : base(userID, clientID, pool, provider, clientSecret, status, username, attributes)
        {
        }
        public virtual new Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
        {
            return base.StartWithAdminNoSrpAuthAsync(adminAuthRequest);
        }
    }
```
This PR makes the methods of CognitoUser virtual so we can write mock test cases for `CognitoUser` class. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
