### PR TITLE
Update AWS SDK package references upper bound to 4.0

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -46,8 +46,8 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 3.4)" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 3.4)" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 4.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="[3.3.100, 3.4)" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="[3.3.100, 3.4)" />
-    <PackageReference Include="AWSSDK.S3" Version="[3.3.100, 3.4)" />
+    <PackageReference Include="AWSSDK.Core" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.3.100, 4.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
To allow usage of AWSSDKs with version less than equal to 4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
