### PR TITLE
Feature/add totp challenge

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -111,19 +111,35 @@ namespace Amazon.Extensions.CognitoAuthentication
     }
 
     /// <summary>
-    /// Class containing the necessary properities to respond to an SMS MFA authentication challenge
+    /// Class containing the necessary properities to respond to an MFA authentication challenge
     /// </summary>
-    public class RespondToSmsMfaRequest
+    public class RespondToMfaRequest
     {
         /// <summary>
         /// The session ID for the current authentication flow.
         /// </summary>
-        public string SessionID { get; set; }
+        public virtual string SessionID { get; set; }
 
         /// <summary>
         /// The MFA verification code needed to authenticate the user.
         /// </summary>
-        public string MfaCode { get; set; }
+        public virtual string MfaCode { get; set; }
+
+        /// <summary>
+        /// The MFA verification code needed to authenticate the user.
+        /// </summary>
+        public virtual ChallengeNameType ChallengeType { get; set; }        
+    }
+
+    /// <summary>
+    /// Class containing the necessary properities to respond to an MFA authentication challenge
+    /// </summary>
+    public class RespondToSmsMfaRequest : RespondToMfaRequest
+    {
+        /// <summary>
+        /// The MFA verification code needed to authenticate the user.
+        /// </summary>
+        public virtual ChallengeNameType ChallengeType { get { return ChallengeNameType.SMS_MFA; } set { } }
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -128,7 +128,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// The MFA verification code needed to authenticate the user.
         /// </summary>
-        public virtual ChallengeNameType ChallengeType { get; set; }        
+        public virtual ChallengeNameType ChallengeNameType { get; set; }        
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -126,7 +126,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         public virtual string MfaCode { get; set; }
 
         /// <summary>
-        /// The MFA verification code needed to authenticate the user.
+        /// The challenge name type for the current authentication flow.
         /// </summary>
         public virtual ChallengeNameType ChallengeNameType { get; set; }        
     }
@@ -137,9 +137,9 @@ namespace Amazon.Extensions.CognitoAuthentication
     public class RespondToSmsMfaRequest : RespondToMfaRequest
     {
         /// <summary>
-        /// The MFA verification code needed to authenticate the user.
+        /// The challenge name type for the current authentication flow.
         /// </summary>
-        public virtual ChallengeNameType ChallengeType { get { return ChallengeNameType.SMS_MFA; } set { } }
+        public override ChallengeNameType ChallengeNameType { get { return ChallengeNameType.SMS_MFA; } set { } }
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -139,16 +139,29 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
         {
+            return await RespondToMfaAuthAsync(smsMfaRequest).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
+        /// authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="smsMfaRequest">RespondToSmsMfaRequest object containing the necessary parameters to
+        /// respond to the current MFA authentication challenge</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest)
+        {
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {
                 ChallengeResponses = new Dictionary<string, string>
                     {
-                        { CognitoConstants.ChlgParamSmsMfaCode, smsMfaRequest.MfaCode},
+                        { ChallengeParamCodeType(mfaRequest.ChallengeType), mfaRequest.MfaCode},
                         { CognitoConstants.ChlgParamUsername, Username }
                     },
-                Session = smsMfaRequest.SessionID,
+                Session = mfaRequest.SessionID,
                 ClientId = ClientID,
-                ChallengeName = ChallengeNameType.SMS_MFA
+                ChallengeName = mfaRequest.ChallengeType
             };
 
             if (!string.IsNullOrEmpty(SecretHash))
@@ -166,6 +179,14 @@ namespace Amazon.Extensions.CognitoAuthentication
                 challengeResponse.ChallengeName,
                 challengeResponse.ChallengeParameters,
                 new Dictionary<string, string>(challengeResponse.ResponseMetadata.Metadata));
+        }    
+        
+        private string ChallengeParamCodeType(ChallengeNameType challengeType)
+        {
+            if (challengeType == ChallengeNameType.SMS_MFA) return CognitoConstants.ChlgParamSmsMfaCode;
+            if (challengeType == ChallengeNameType.SOFTWARE_TOKEN_MFA) return CognitoConstants.ChlgParamSoftwareTokenMfaCode;
+            
+            return null;
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -146,7 +146,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
         /// authentication challenge using an asynchronous call
         /// </summary>
-        /// <param name="smsMfaRequest">RespondToSmsMfaRequest object containing the necessary parameters to
+        /// <param name="mfaRequest">RespondToMfaRequest object containing the necessary parameters to
         /// respond to the current MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
@@ -156,12 +156,12 @@ namespace Amazon.Extensions.CognitoAuthentication
             {
                 ChallengeResponses = new Dictionary<string, string>
                     {
-                        { ChallengeParamCodeType(mfaRequest.ChallengeType), mfaRequest.MfaCode},
+                        { GetChallengeParamCodeName(mfaRequest.ChallengeNameType), mfaRequest.MfaCode},
                         { CognitoConstants.ChlgParamUsername, Username }
                     },
                 Session = mfaRequest.SessionID,
                 ClientId = ClientID,
-                ChallengeName = mfaRequest.ChallengeType
+                ChallengeName = mfaRequest.ChallengeNameType
             };
 
             if (!string.IsNullOrEmpty(SecretHash))
@@ -179,13 +179,18 @@ namespace Amazon.Extensions.CognitoAuthentication
                 challengeResponse.ChallengeName,
                 challengeResponse.ChallengeParameters,
                 new Dictionary<string, string>(challengeResponse.ResponseMetadata.Metadata));
-        }    
-        
-        private string ChallengeParamCodeType(ChallengeNameType challengeType)
+        }
+
+        /// <summary>
+        /// Internal method which works out which Challenge Parameter to use based on the ChallengeTypeName
+        /// </summary>
+        /// <param name="challengeNameType">ChallengeTypeName from the challenge</param>
+        /// <returns>Returns the CognitoConstants for the given ChallengeTypeName</returns>
+        private string GetChallengeParamCodeName(ChallengeNameType challengeNameType )
         {
-            if (challengeType == ChallengeNameType.SMS_MFA) return CognitoConstants.ChlgParamSmsMfaCode;
-            if (challengeType == ChallengeNameType.SOFTWARE_TOKEN_MFA) return CognitoConstants.ChlgParamSoftwareTokenMfaCode;
-            
+            if (challengeNameType == ChallengeNameType.SMS_MFA) return CognitoConstants.ChlgParamSmsMfaCode;
+            if (challengeNameType == ChallengeNameType.SOFTWARE_TOKEN_MFA) return CognitoConstants.ChlgParamSoftwareTokenMfaCode;
+
             return null;
         }
 

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoConstants.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoConstants.cs
@@ -35,6 +35,7 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
         public static readonly string ChlgParamDeliveryMed = "CODE_DELIVERY_DELIVERY_MEDIUM";
 
         public static readonly string ChlgParamSmsMfaCode = "SMS_MFA_CODE";
+        public static readonly string ChlgParamSoftwareTokenMfaCode = "SOFTWARE_TOKEN_MFA_CODE";        
         public static readonly string ChlgParamDeviceKey = "DEVICE_KEY";
 
         public static readonly string ChlgParamUserAttrs = "userAttributes";


### PR DESCRIPTION
#55 
#56 

*Description of changes:*
Added support for TOTP challenges, supports the existing way by defaulting to SMS, but also has an additional override method to allow setting the challenge type.

I have also done the changes to the identity provider on the other repo to automatically support the 2fa differences, currently, these changes are on my fork until this is merged as the other branch relies on changes from this branch for the RespondToMfaRquest class

I have seen other pull requests which are approved but not merged from what I can see, but these do not seem to be backwardly compatible, and also there is no other pull request on the identity provider to also update that to support the required changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
