### PR TITLE
Update version numbers for AWSSDK.CognitoIdentity and AWSSDK.CognitoI…

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>1.0.4</PackageVersion>
+    <PackageVersion>2.0.0</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.4</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <Choose>
@@ -46,8 +46,8 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 4.0)" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.5.0.2" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.5.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…dentityProvider

*Issue #, if available:*
#57 

*Description of changes:*
Update the version numbers for AWSSDK.CognitoIdentity and AWSSDK.CognitoIdentityProvider references from (>= 3.3.100 && < 3.4.0) to 3.5.0.2 to work with latest AWS SDK v3.5 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
