### PR TITLE
Fixes an issue where RefreshToken is lost when executing StartWithRefreshTokenAuthAsync

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>2.0.1</PackageVersion>
+    <PackageVersion>2.0.2</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -413,6 +413,10 @@ namespace Amazon.Extensions.CognitoAuthentication
             InitiateAuthResponse initiateResponse =
                 await Provider.InitiateAuthAsync(initiateAuthRequest).ConfigureAwait(false);
 
+            // Service does not return the refresh token. Hence, set it to the old refresh token that was used.
+            if (string.IsNullOrEmpty(initiateResponse.ChallengeName) && string.IsNullOrEmpty(initiateResponse.AuthenticationResult.RefreshToken))
+                initiateResponse.AuthenticationResult.RefreshToken = initiateAuthRequest.AuthParameters[CognitoConstants.ChlgParamRefreshToken];
+
             UpdateSessionIfAuthenticationComplete(initiateResponse.ChallengeName, initiateResponse.AuthenticationResult);
 
             return new AuthFlowResponse(initiateResponse.Session,


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-net-extensions-cognito/issues/22

*Issue #, if available:* https://github.com/aws/aws-sdk-net-extensions-cognito/issues/22

*Description of changes:*
Reloads the RefreshToken from initial request since service does not return back the RefreshToken for `refresh_token` auth flow.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
