### PR TITLE
Fix Device level auth issue

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>2.0.3</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
+    <Version>2.0.3</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/* The following knowledge base was used as guide for the implementation 
+ * of some of the below Cognito challenges.
+ * https://aws.amazon.com/premiumsupport/knowledge-center/cognito-user-pool-remembered-devices/?nc1=h_ls
+ */
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -149,7 +154,7 @@ namespace Amazon.Extensions.CognitoAuthentication
 
             string timeStr = DateTime.UtcNow.ToString("ddd MMM d HH:mm:ss \"UTC\" yyyy", CultureInfo.InvariantCulture);
 
-            var claimBytes = AuthenticationHelper.AuthenticateDevice(deviceKey, devicePassword, deviceKeyGroup, salt,
+            var claimBytes = AuthenticationHelper.AuthenticateDevice(username, deviceKey, devicePassword, deviceKeyGroup, salt,
                 challenge.ChallengeParameters[CognitoConstants.ChlgParamSrpB], secretBlock, timeStr, tupleAa);
 
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -60,9 +60,10 @@ namespace Amazon.Extensions.CognitoAuthentication
 
             RespondToAuthChallengeResponse verifierResponse =
                 await Provider.RespondToAuthChallengeAsync(challengeRequest).ConfigureAwait(false);
-
+            var isDeviceAuthRequest = verifierResponse.AuthenticationResult == null && (!string.IsNullOrEmpty(srpRequest.DeviceGroupKey)
+                || !string.IsNullOrEmpty(srpRequest.DevicePass));
             #region Device-level authentication
-            if (verifierResponse.AuthenticationResult == null)
+            if (isDeviceAuthRequest)
             {
                 if (string.IsNullOrEmpty(srpRequest.DeviceGroupKey) || string.IsNullOrEmpty(srpRequest.DevicePass))
                 {

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="[3.3.100, 4.0)" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="[3.3.100, 4.0)" />
-    <PackageReference Include="AWSSDK.S3" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.58" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.58" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.7.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
*Description of changes:*
Fix Device level auth region in StartWithSRPAuth in order to avoid error
"Device Group Key and Device Pass required for authentication."
for requests without a device

Also fix invalid username or password issue with providing device information in StartWithSRPAuth

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
