### PR TITLE
Update AWS SDK Dependencies to 3.7

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,11 +5,11 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>
-    <Copyright>2018</Copyright>
+    <Copyright>2018-2021</Copyright>
     <Description>An extension library to assist in the Amazon Cognito User Pools authentication process.</Description>
     <PackageTags>AWS;Amazon;aws-sdk-v3;Cognito</PackageTags>
     <PackageProjectUrl>https://github.com/aws/aws-sdk-net-extensions-cognito/</PackageProjectUrl>
@@ -29,7 +29,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
   <Choose>
@@ -46,12 +46,12 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.5.0.2" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.5.0.2" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.7.0.2" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.7.0.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath=""/>
-    <None Include="../../icon.png" Pack="true" PackagePath=""/>
+    <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../../icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.58" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.58" />
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.5" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.0.3" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Updates the dependencies on AWS SDK packages to v3.7, and performs a minor version bump.

**Note:** `TestMfaAuthenticationFlow` seems like a flaky integration test, then I hit the daily SES limit in my personal account before getting too far along troubleshooting. I was only able to get all tests to pass locally intermittently.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
