### PR TITLE
Switch all calls from DateTime.Now to DateTime.UtcNow

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -480,7 +480,7 @@ namespace Amazon.Extensions.CognitoAuthentication
             string idToken = authResult.IdToken;
             string accessToken = authResult.AccessToken;
             string refreshToken;
-            DateTime currentTime = DateTime.Now;
+            DateTime currentTime = DateTime.UtcNow;
 
             if (!string.IsNullOrEmpty(refreshTokenOverride))
             {

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserSession.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserSession.cs
@@ -73,7 +73,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>Returns a boolean whether the user's tokens are still valid</returns>
         public bool IsValid()
         {
-            DateTime currentTimeStamp = DateTime.Now;
+            DateTime currentTimeStamp = DateTime.UtcNow;
 
             return (currentTimeStamp.CompareTo(ExpirationTime) < 0);
         }

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/BaseAuthenticationTestClass.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/BaseAuthenticationTestClass.cs
@@ -71,7 +71,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
 
             CreateUserPoolRequest createPoolRequest = new CreateUserPoolRequest
             {
-                PoolName = "testPool_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                PoolName = "testPool_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 Policies = passwordPolicy,
                 Schema = requiredAttributes,
                 AdminCreateUserConfig = adminCreateUser,
@@ -88,7 +88,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
 
             CreateUserPoolClientRequest clientRequest = new CreateUserPoolClientRequest()
             {
-                ClientName = "App_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                ClientName = "App_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 UserPoolId = userPoolCreated.Id,
                 GenerateSecret = false,
 

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
@@ -65,7 +65,7 @@ namespace CognitoAuthentication.IntegrationTests.NET45
                     {
                         new CognitoIdentityProviderInfo() { ProviderName = providerName, ClientId = user.ClientID}
                     },
-                    IdentityPoolName = "TestIdentityPool" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                    IdentityPoolName = "TestIdentityPool" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
 
                 }).ConfigureAwait(false);
             identityPoolId = poolResponse.IdentityPoolId;
@@ -74,7 +74,7 @@ namespace CognitoAuthentication.IntegrationTests.NET45
             managementClient = new AmazonIdentityManagementServiceClient(clientCredentials, clientRegion);
             CreateRoleResponse roleResponse = managementClient.CreateRoleAsync(new CreateRoleRequest()
             {
-                RoleName = "_TestRole_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                RoleName = "_TestRole_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 AssumeRolePolicyDocument = "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect" +
                 "\": \"Allow\",\"Principal\": {\"Federated\": \"cognito-identity.amazonaws.com\"}," +
                 "\"Action\": \"sts:AssumeRoleWithWebIdentity\"}]}"
@@ -87,7 +87,7 @@ namespace CognitoAuthentication.IntegrationTests.NET45
                 PolicyDocument = "{\"Version\": \"2012-10-17\",\"Statement\": " +
                 "[{\"Effect\": \"Allow\",\"Action\": [\"mobileanalytics:PutEvents\",\"cog" +
                 "nito-sync:*\",\"cognito-identity:*\",\"s3:*\"],\"Resource\": [\"*\"]}]}",
-                PolicyName = "_Cognito_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                PolicyName = "_Cognito_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
             }).Result;
             policyArn = policyResponse.Policy.Arn;
 

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
@@ -115,7 +115,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             {
                 CreateRoleResponse roleResponse = managementClient.CreateRoleAsync(new CreateRoleRequest()
                 {
-                    RoleName = "TestRole_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                    RoleName = "TestRole_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                     AssumeRolePolicyDocument = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow" +
                     "\",\"Principal\":{\"Service\":\"cognito-idp.amazonaws.com\"},\"Action\":\"sts:AssumeRole\",\"Condition" +
                     "\":{\"StringEquals\":{\"sts:ExternalId\":\"8327d096-57c0-4fb7-ad24-62ea8fc692c0\"}}}]}"
@@ -129,7 +129,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
                 {
                     PolicyDocument = "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Action" +
                     "\": [\"sns:publish\"],\"Resource\": [\"*\"]}]}",
-                    PolicyName = "Cognito_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                    PolicyName = "Cognito_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 }).Result;
 
                 policyName = createPolicyResponse.Policy.PolicyName;
@@ -145,7 +145,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             //Create user pool and client
             CreateUserPoolRequest createPoolRequest = new CreateUserPoolRequest
             {
-                PoolName = "mfaTestPool_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"),
+                PoolName = "mfaTestPool_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 Policies = passwordPolicy,
                 Schema = requiredAttributes,
                 AdminCreateUserConfig = adminCreateUser,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/69#issuecomment-819463129

*Description of changes:*
Replace all uses of `DateTime.Now` with `DateTime.UtcNow`.

The **CognitoUser.cs** class had incorrect line endings which is why it is showing a full file change. I committed it this way to get the file fixed up for going forward. There was one actual file change on line 483 to change to UtcNow.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
