### PR TITLE
Fixed issues for Refresh Token auth flow.

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Amazon.Extensions.CognitoAuthentication</AssemblyName>
     <RootNamespace>Amazon.Extensions.CognitoAuthentication</RootNamespace>
     <PackageId>Amazon.Extensions.CognitoAuthentication</PackageId>
-    <PackageVersion>2.2.1</PackageVersion>
+    <PackageVersion>2.2.2</PackageVersion>
     <Title>Amazon Cognito Authentication Extension Library</Title>
     <Product>Amazon.Extensions.CognitoAuthentication</Product>
     <Authors>Amazon Web Services</Authors>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -585,8 +585,6 @@ namespace Amazon.Extensions.CognitoAuthentication
 
         private InitiateAuthRequest CreateRefreshTokenAuthRequest(AuthFlowType authFlowType)
         {
-            EnsureUserAuthenticated();
-
             if (authFlowType != AuthFlowType.REFRESH_TOKEN && authFlowType != AuthFlowType.REFRESH_TOKEN_AUTH)
             {
                 throw new ArgumentException("authFlowType must be either \"REFRESH_TOKEN\" or \"REFRESH_TOKEN_AUTH\"", "authFlowType");

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserSession.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserSession.cs
@@ -63,8 +63,8 @@ namespace Amazon.Extensions.CognitoAuthentication
             this.IdToken = idToken;
             this.AccessToken = accessToken;
             this.RefreshToken = refreshToken;
-            this.IssuedTime = issuedTime;
-            this.ExpirationTime = expirationTime;
+            this.IssuedTime = issuedTime.ToUniversalTime();
+            this.ExpirationTime = expirationTime.ToUniversalTime();
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #:* #76 #77 #75

*Description of changes:*
Following issues are addressed in this PR:
- Removed check to validate `CognitoSessionTokens` which checks `ExpirationTime` for REFRESH_TOKEN Auth Flow.
- Fixed an issue where IssuedTime and ExpirationTime for `CognitoUserSession` object should be in UTC when it is instantiated manually by user.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
