### PR TITLE
Increased timeout for intermittent test failure and fixed cleanup process

### DIFF
--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
@@ -109,7 +109,7 @@ namespace CognitoAuthentication.IntegrationTests.NET45
                     { "unauthenticated", roleResponse.Role.Arn }
                 },
             }).ConfigureAwait(false);
-
+            
             //Create and test credentials
             CognitoAWSCredentials credentials = user.GetCognitoAWSCredentials(identityPoolId, clientRegion);
 
@@ -126,7 +126,7 @@ namespace CognitoAuthentication.IntegrationTests.NET45
                     }
                     catch (Exception ex)
                     {
-                        System.Threading.Thread.Sleep(3000);
+                        System.Threading.Thread.Sleep(5000);
                     }
                 }
 
@@ -139,30 +139,30 @@ namespace CognitoAuthentication.IntegrationTests.NET45
         /// Internal method that cleans up the created identity pool (along with associated 
         /// clients/roles) for testing
         /// </summary>
-        public override async void Dispose()
+        public override void Dispose()
         {
             try
             {
-                await identityClient.DeleteIdentityPoolAsync(new DeleteIdentityPoolRequest()
+                identityClient.DeleteIdentityPoolAsync(new DeleteIdentityPoolRequest()
                 {
                     IdentityPoolId = identityPoolId
-                }).ConfigureAwait(false);
+                }).GetAwaiter().GetResult();
 
-                await managementClient.DetachRolePolicyAsync(new DetachRolePolicyRequest()
+                managementClient.DetachRolePolicyAsync(new DetachRolePolicyRequest()
                 {
                     PolicyArn = policyArn,
                     RoleName = roleName
-                }).ConfigureAwait(false);
+                }).GetAwaiter().GetResult();
 
-                await managementClient.DeletePolicyAsync(new DeletePolicyRequest()
+                managementClient.DeletePolicyAsync(new DeletePolicyRequest()
                 {
                     PolicyArn = policyArn
-                }).ConfigureAwait(false);
+                }).GetAwaiter().GetResult();
 
-                await managementClient.DeleteRoleAsync(new DeleteRoleRequest()
+                managementClient.DeleteRoleAsync(new DeleteRoleRequest()
                 {
                     RoleName = roleName
-                }).ConfigureAwait(false);
+                }).GetAwaiter().GetResult();
 
                 identityClient.Dispose();
                 managementClient.Dispose();

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
@@ -161,6 +161,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             //Build in buffer time for role/policy to be created
             CreateUserPoolResponse createPoolResponse = null;
             string bufferExMsg = "Role does not have a trust relationship allowing Cognito to assume the role";
+            string bufferExMsgSNSPublish = "Role does not have permission to publish with SNS";
             while (true)
             {
                 try
@@ -168,16 +169,9 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
                     createPoolResponse = provider.CreateUserPoolAsync(createPoolRequest).Result;
                     break;
                 }
-                catch(Exception ex)
+                catch (Exception ex) when (ex.InnerException != null && (bufferExMsg.Equals(ex.InnerException.Message) || bufferExMsgSNSPublish.Equals(ex.InnerException.Message)))
                 {
-                    if (string.Equals(bufferExMsg, ex.InnerException.Message))
-                    {
-                        System.Threading.Thread.Sleep(3000);
-                    }
-                    else
-                    {
-                        throw ex;
-                    }
+                    System.Threading.Thread.Sleep(3000);
                 }
              }
 


### PR DESCRIPTION
*Issue #, if available:*
Recent changes for Cognito pipeline reported test failures.

*Description of changes:*
Fixed the following tests for failures:
- **Amazon.Extensions.CognitoAuthentication.IntegrationTests.MfaAuthenticationTests.TestMfaAuthenticationFlow**: Sometimes, the user pool creation was giving `Role does not have permission to publish with SNS` exception. This needs to be included in buffer exceptions.
- **CognitoAuthentication.IntegrationTests.NET45.CognitoCredentialsTests.TestGetCognitoAWSCredentials**: Intermittent issue fixed by increasing the timeout. Also, the test was not able to cleanup resources due to use of `await` and not waiting for cleanup to complete. As a result of this, there were left over user pools, roles and identity pools. Fixed the cleanup process to wait for cleanup operation to complete.

**NOTE:** Switching `await DoThingAsync()` to `DoThingAsync().Wait()` is usually a very bad idea. However, in current scenario, since the test process exits, awaiting is aborted and resources are not cleaned up. Refer the other test case `Amazon.Extensions.CognitoAuthentication.IntegrationTests.MfaAuthenticationTests.TestMfaAuthenticationFlow`, it Wait(s). Also, the resources have to be cleaned up in specific order and awaiting normally might not guarantee the order in which the API calls would be executed.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
