### PR TITLE
Allow CognitoUser.RespondToCustomAuthAsync to include ClientMetadata

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -181,6 +181,11 @@ namespace Amazon.Extensions.CognitoAuthentication
         public IDictionary<string, string> ChallengeParameters { get; set; }
 
         /// <summary>
+        /// The client metadata for any custom workflows that this action triggers
+        /// </summary>
+        public IDictionary<string, string> ClientMetadata { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
         /// The sessionID for the current authentication flow.
         /// </summary>
         public string SessionID { get; set; }

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -229,6 +229,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 ChallengeName = ChallengeNameType.CUSTOM_CHALLENGE,
                 ClientId = ClientID,
                 ChallengeResponses = new Dictionary<string, string>(customRequest.ChallengeParameters),
+                ClientMetadata = new Dictionary<string, string>(customRequest.ClientMetadata),
                 Session = customRequest.SessionID
             };
 


### PR DESCRIPTION
The current implementation of `CognitoUser.RespondToCustomAuthAsync` does not support setting the `ClientMetadata` property of the `RespondToAuthChallengeRequest` object, despite it [being supported by the API](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html#API_RespondToAuthChallenge_RequestSyntax).

This PR rectifies this by adding a `ClientMetadata` dictionary property to the `RespondToCustomChallengeRequest` dto, which is then used in building the `RespondToAuthChallengeRequest` object.

The new property added to the `RespondToCustomChallengeRequest` dto is using an object initialiser to ensure backwards compatibility. Without it, consumers upgrading to a version of this package containing this change will experience an `ArgumentNullException` when calling `RespondToCustomAuthAsync` as `ClientMetadata` will be set to `new new Dictionary<string, string>(customRequest.ClientMetadata)` with `customRequest.ClientMetadata` being `null`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
