### PR TITLE
Add ClientMetadata to SRP auth flow

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -91,6 +91,10 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// The Device Key Group for the device associated with the corresponding CognitoUser
         /// </summary>
         public string DeviceGroupKey { get; set; }
+        /// <summary>
+        /// The client metadata for the current authentication flow.
+        /// </summary>
+        public IDictionary<string, string> ClientMetadata { get; set; }
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -55,7 +55,10 @@ namespace Amazon.Extensions.CognitoAuthentication
             RespondToAuthChallengeRequest challengeRequest =
                 CreateSrpPasswordVerifierAuthRequest(initiateResponse, srpRequest.Password, tupleAa);
 
-            challengeRequest.ClientMetadata = new Dictionary<string, string>(srpRequest.ClientMetadata);
+            if (srpRequest.ClientMetadata != null)
+            {
+                challengeRequest.ClientMetadata = new Dictionary<string, string>(srpRequest.ClientMetadata);
+            }
 
             bool challengeResponsesValid = challengeRequest != null && challengeRequest.ChallengeResponses != null;
             bool deviceKeyValid = Device != null && !string.IsNullOrEmpty(Device.DeviceKey);

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -55,6 +55,8 @@ namespace Amazon.Extensions.CognitoAuthentication
             RespondToAuthChallengeRequest challengeRequest =
                 CreateSrpPasswordVerifierAuthRequest(initiateResponse, srpRequest.Password, tupleAa);
 
+            challengeRequest.ClientMetadata = new Dictionary<string, string>(srpRequest.ClientMetadata);
+
             bool challengeResponsesValid = challengeRequest != null && challengeRequest.ChallengeResponses != null;
             bool deviceKeyValid = Device != null && !string.IsNullOrEmpty(Device.DeviceKey);
 


### PR DESCRIPTION
*Description of changes:*
Adds `ClientMetadata` to the SRP flow. This enables [Cognito Lambda Triggers](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html) to have access to the `ClientMetadata`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
