### PR TITLE
Allow CUSTOM_AUTH authentication flow via SRP password verification

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoAuthenticationClasses.cs
@@ -91,6 +91,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// The Device Key Group for the device associated with the corresponding CognitoUser
         /// </summary>
         public string DeviceGroupKey { get; set; }
+        public bool IsCustomAuthFlow { get; set; }
     }
 
     /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -49,6 +49,11 @@ namespace Amazon.Extensions.CognitoAuthentication
             Tuple<BigInteger, BigInteger> tupleAa = AuthenticationHelper.CreateAaTuple();
             InitiateAuthRequest initiateRequest = CreateSrpAuthRequest(tupleAa);
 
+            if (srpRequest.IsCustomAuthFlow)
+            {
+                initiateRequest.AuthFlow = AuthFlowType.CUSTOM_AUTH;
+                initiateRequest.AuthParameters.Add("CHALLENGE_NAME", "SRP_A");
+            }
             InitiateAuthResponse initiateResponse = await Provider.InitiateAuthAsync(initiateRequest).ConfigureAwait(false);
             UpdateUsernameAndSecretHash(initiateResponse.ChallengeParameters);
 


### PR DESCRIPTION
*Issue #, #79
The custom authentication flow can be used with standard SRP password verification. The initial challenge is done using SRP and the custom authentication can provide MFA challenge such as email.

More information on this can be found here.
https://aws.amazon.com/blogs/mobile/extending-amazon-cognito-with-email-otp-for-2fa-using-amazon-ses/

*Description of changes:*

Allows the InitiateSrpAuthRequest to work with the custom authentication flow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
