### PR TITLE
Added support for generic CognitoUser in CognitoUserPool

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -143,7 +143,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Gets a CognitoUser with no userID set
         /// </summary>
         /// <returns>Returns a user with no userID set</returns>
-        public CognitoUser GetUser()
+        public virtual CognitoUser GetUser()
         {
             return new CognitoUser(null, ClientID, this, Provider, ClientSecret);
         }
@@ -153,7 +153,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="userID">The userID of the corresponding user</param>
         /// <returns>Returns a CognitoUser with the corresponding userID</returns>
-        public CognitoUser GetUser(string userID)
+        public virtual CognitoUser GetUser(string userID)
         {
             if (string.IsNullOrEmpty(userID))
             {
@@ -170,7 +170,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="status">The status of the corresponding user</param>
         /// <param name="attributes">The attributes of the corresponding user</param>
         /// <returns>Returns a CognitoUser with the corresponding userID</returns>
-        public CognitoUser GetUser(string userID, string status, Dictionary<string,string> attributes)
+        public virtual CognitoUser GetUser(string userID, string status, Dictionary<string,string> attributes)
         {
             if (string.IsNullOrEmpty(userID))
             {
@@ -185,7 +185,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="userID">The userID of the corresponding user</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
-        public async Task<CognitoUser> FindByIdAsync(string userID)
+        public virtual async Task<CognitoUser> FindByIdAsync(string userID)
         {
             if (string.IsNullOrEmpty(userID))
                 throw new ArgumentException(nameof(userID));


### PR DESCRIPTION
Description of changes:
The issue is related to the https://github.com/aws/aws-aspnet-cognito-identity-provider package when used with a custom ApplicationUser class inherited from CognitoUser. The problem is that CognitoUserStore<TUser> in methods FindByEmailAsync and FindByIdAsync use CognitoUserPool to get the user and then tries to upcast this instance which obviously leads to the user being null.

Adding virtual modifiers will allow changing the implementation of CognitoUserPool methods to return custom own instances.

I understand that I can create a new inherited from CognitoUserStore implementation of the store to override these 2 methods with a custom CognitoUserPool, but this PR will reduce this boilerplate code.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
