### PR TITLE
Add Caching to GetAssemblyFileVersion

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -48,7 +48,6 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.7.0.2" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.7.0.2" />
-    <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.7.0.2" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.7.0.2" />
+    <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
@@ -61,8 +61,6 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
             }
         }
         
-        private const string AssemblyFileVersionCachePath = "Cognito.AssemblyFileVersion";
-
         /// <summary>
         /// Computes the secret hash for the user pool using the corresponding userID, clientID, 
         /// and client secret


### PR DESCRIPTION
*Issue #107*

https://github.com/aws/aws-sdk-net-extensions-cognito/issues/107

This PR adds caching to the AssemblyFileVersion using System.Runtime.Caching to prevent making a call to fetch the assembly everytime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
