### PR TITLE
fix: Restore public method signatures that do not take a cancellation token

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -28,7 +28,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.1</Version>
+    <Version>2.4.2</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
@@ -156,7 +156,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Gets the device from the Cognito service using the device key and user's access 
         /// token using an asynchronous call
         /// </summary>
-        public async Task GetDeviceAsync(CancellationToken cancellationToken = default)
+        public async Task GetDeviceAsync()
+        {
+            await GetDeviceAsync(default);
+        }
+
+        /// <summary>
+        /// Gets the device from the Cognito service using the device key and user's access 
+        /// token using an asynchronous call
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public async Task GetDeviceAsync(CancellationToken cancellationToken)
         {
             GetDeviceRequest getDeviceRequest = CreateGetDeviceRequest();
 
@@ -170,7 +180,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Forgets the device associated with the CognitoDevice's device key using
         /// an asynchronous call
         /// </summary>
-        public Task ForgetDeviceAsync(CancellationToken cancellationToken = default)
+        public Task ForgetDeviceAsync()
+        {
+            return ForgetDeviceAsync(default);
+        }
+
+        /// <summary>
+        /// Forgets the device associated with the CognitoDevice's device key using
+        /// an asynchronous call
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public Task ForgetDeviceAsync(CancellationToken cancellationToken)
         {
             ForgetDeviceRequest forgetDeviceRequest = CreateForgetDeviceRequest();
             return User.Provider.ForgetDeviceAsync(forgetDeviceRequest, cancellationToken);
@@ -179,7 +199,16 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// Updates the device status to be remembered using an asynchronous call
         /// </summary>
-        public Task RememberThisDeviceAsync(CancellationToken cancellationToken = default)
+        public Task RememberThisDeviceAsync()
+        {
+            return RememberThisDeviceAsync(default);
+        }
+
+        /// <summary>
+        /// Updates the device status to be remembered using an asynchronous call
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public Task RememberThisDeviceAsync(CancellationToken cancellationToken)
         {
             UpdateDeviceStatusRequest updateRequest =
                 CreateUpdateDeviceStatusRequest(new DeviceRememberedStatusType(CognitoConstants.DeviceAttrRemembered));
@@ -190,7 +219,16 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// Updates the device status to not be remembered using an asynchronous call
         /// </summary>
-        public Task DoNotRememberThisDeviceAsync(CancellationToken cancellationToken = default)
+        public Task DoNotRememberThisDeviceAsync()
+        {
+            return DoNotRememberThisDeviceAsync(default);
+        }
+
+        /// <summary>
+        /// Updates the device status to not be remembered using an asynchronous call
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public Task DoNotRememberThisDeviceAsync(CancellationToken cancellationToken)
         {
             UpdateDeviceStatusRequest updateRequest =
                     CreateUpdateDeviceStatusRequest(new DeviceRememberedStatusType(CognitoConstants.DeviceAttrNotRemembered));

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -157,6 +157,16 @@ namespace Amazon.Extensions.CognitoAuthentication
                 eventProvider.BeforeRequestEvent += CognitoAuthHelper.ServiceClientBeforeRequestEvent;
             }
         }
+        /// <summary>
+        /// Confirms the sign up of the associated user using the provided confirmation code
+        /// using an asynchronous call
+        /// </summary>
+        /// <param name="confirmationCode">Confirmation code sent to user via email or SMS</param>
+        /// <param name="forcedAliasCreation">Boolean specifying whether forced alias creation is desired</param>
+        public virtual Task ConfirmSignUpAsync(string confirmationCode, bool forcedAliasCreation)
+        {
+            return ConfirmSignUpAsync(confirmationCode, forcedAliasCreation, default);
+        }
 
         /// <summary>
         /// Confirms the sign up of the associated user using the provided confirmation code
@@ -164,7 +174,8 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="confirmationCode">Confirmation code sent to user via email or SMS</param>
         /// <param name="forcedAliasCreation">Boolean specifying whether forced alias creation is desired</param>
-        public virtual Task ConfirmSignUpAsync(string confirmationCode, bool forcedAliasCreation, CancellationToken cancellationToken = default)
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task ConfirmSignUpAsync(string confirmationCode, bool forcedAliasCreation, CancellationToken cancellationToken)
         {
             ConfirmSignUpRequest confirmRequest = CreateConfirmSignUpRequest(confirmationCode, forcedAliasCreation);
 
@@ -175,7 +186,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Request to resend registration confirmation code for a user using an asynchronous call
         /// </summary>
         /// <returns>Returns the delivery details for the confirmation code request</returns>
-        public virtual Task ResendConfirmationCodeAsync(CancellationToken cancellationToken = default)
+        public virtual Task ResendConfirmationCodeAsync()
+        {
+            return ResendConfirmationCodeAsync(default);
+        }
+
+        /// <summary>
+        /// Request to resend registration confirmation code for a user using an asynchronous call
+        /// </summary>
+        /// <returns>Returns the delivery details for the confirmation code request</returns>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task ResendConfirmationCodeAsync(CancellationToken cancellationToken)
         {
             ResendConfirmationCodeRequest resendRequest = CreateResendConfirmationCodeRequest();
 
@@ -186,20 +207,41 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Allows the user to reset their password using an asynchronous call. Should be used in 
         /// conjunction with the ConfirmPasswordAsync method 
         /// </summary>
-        public virtual Task ForgotPasswordAsync(CancellationToken cancellationToken = default)
+        public virtual Task ForgotPasswordAsync()
+        {
+            return ForgotPasswordAsync(default);
+        }
+
+        /// <summary>
+        /// Allows the user to reset their password using an asynchronous call. Should be used in 
+        /// conjunction with the ConfirmPasswordAsync method 
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task ForgotPasswordAsync(CancellationToken cancellationToken)
         {
             ForgotPasswordRequest forgotPassRequest = CreateForgotPasswordRequest();
 
             return Provider.ForgotPasswordAsync(forgotPassRequest, cancellationToken);
+        }
+        /// <summary>
+        /// Confirms the user's new password using the confirmation code sent to them using
+        /// an asynchronous call
+        /// </summary>
+        /// <param name="confirmationCode">The confirmation code sent to the user</param>
+        /// <param name="newPassword">The new desired password for the user</param>
+        public virtual Task ConfirmForgotPasswordAsync(string confirmationCode, string newPassword)
+        {
+            return ConfirmForgotPasswordAsync(confirmationCode, newPassword, default);
         }
 
         /// <summary>
         /// Confirms the user's new password using the confirmation code sent to them using
         /// an asynchronous call
         /// </summary>
-        /// <param name="confirmationCode">The confirmation code sent to the suer</param>
+        /// <param name="confirmationCode">The confirmation code sent to the user</param>
         /// <param name="newPassword">The new desired password for the user</param>
-        public virtual Task ConfirmForgotPasswordAsync(string confirmationCode, string newPassword, CancellationToken cancellationToken = default)
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task ConfirmForgotPasswordAsync(string confirmationCode, string newPassword, CancellationToken cancellationToken)
         {
             ConfirmForgotPasswordRequest confirmResetPassRequest =
                 CreateConfirmPasswordRequest(confirmationCode, newPassword);
@@ -213,7 +255,19 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="oldPass">The user's old password</param>
         /// <param name="newPass">The desired new password</param>
-        public virtual Task ChangePasswordAsync(string oldPass, string newPass, CancellationToken cancellationToken = default)
+        public virtual Task ChangePasswordAsync(string oldPass, string newPass)
+        {
+            return ChangePasswordAsync(oldPass, newPass, default);
+        }
+
+        /// <summary>
+        /// Allows an authenticated user to change their password using an
+        /// asynchronous call
+        /// </summary>
+        /// <param name="oldPass">The user's old password</param>
+        /// <param name="newPass">The desired new password</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task ChangePasswordAsync(string oldPass, string newPass, CancellationToken cancellationToken)
         {
             ChangePasswordRequest changePassRequest = CreateChangePasswordRequest(oldPass, newPass);
 
@@ -224,7 +278,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Gets the details for the current user using an asynchronous call
         /// </summary>
         /// <returns>Returns a tuple containing the user attributes and settings, in that order</returns>
-        public virtual Task<GetUserResponse> GetUserDetailsAsync(CancellationToken cancellationToken = default)
+        public virtual Task<GetUserResponse> GetUserDetailsAsync()
+        {
+            return GetUserDetailsAsync(default);
+        }
+
+        /// <summary>
+        /// Gets the details for the current user using an asynchronous call
+        /// </summary>
+        /// <returns>Returns a tuple containing the user attributes and settings, in that order</returns>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task<GetUserResponse> GetUserDetailsAsync(CancellationToken cancellationToken)
         {
             EnsureUserAuthenticated();
 
@@ -243,7 +307,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="medium">Name of the attribute the verification code is being sent to.
         /// Should be either email or phone_number.</param>
         /// <returns>Returns the delivery details for the attribute verification code request</returns>
-        public virtual Task GetAttributeVerificationCodeAsync(string medium, CancellationToken cancellationToken = default)
+        public virtual Task GetAttributeVerificationCodeAsync(string medium)
+        {
+            return GetAttributeVerificationCodeAsync(medium, default);
+        }
+
+        /// <summary>
+        /// Gets the attribute verification code for the specified attribute using
+        /// an asynchronous call
+        /// </summary>
+        /// <param name="medium">Name of the attribute the verification code is being sent to.
+        /// Should be either email or phone_number.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the delivery details for the attribute verification code request</returns>
+        public virtual Task GetAttributeVerificationCodeAsync(string medium, CancellationToken cancellationToken)
         {
             GetUserAttributeVerificationCodeRequest getAttributeCodeRequest =
                     CreateGetUserAttributeVerificationCodeRequest(medium);
@@ -254,7 +331,16 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <summary>
         /// Sign-out from all devices associated with this user using an asynchronous call
         /// </summary>
-        public virtual Task GlobalSignOutAsync(CancellationToken cancellationToken = default)
+        public virtual Task GlobalSignOutAsync()
+        {
+            return GlobalSignOutAsync(default);
+        }
+
+        /// <summary>
+        /// Sign-out from all devices associated with this user using an asynchronous call
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task GlobalSignOutAsync(CancellationToken cancellationToken)
         {
             EnsureUserAuthenticated();
 
@@ -266,11 +352,19 @@ namespace Amazon.Extensions.CognitoAuthentication
             SessionTokens = null;
             return Provider.GlobalSignOutAsync(globalSignOutRequest, cancellationToken);
         }
+        /// <summary>
+        /// Deletes the current user using an asynchronous call
+        /// </summary>
+        public virtual Task DeleteUserAsync()
+        {
+            return DeleteUserAsync(default);
+        }
 
         /// <summary>
         /// Deletes the current user using an asynchronous call
         /// </summary>
-        public virtual Task DeleteUserAsync(CancellationToken cancellationToken = default)
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task DeleteUserAsync(CancellationToken cancellationToken)
         {
             EnsureUserAuthenticated();
 
@@ -287,7 +381,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="attributeName">Attribute to be verified. Should either be email or phone_number</param>
         /// <param name="verificationCode">The verification code for the attribute being verified</param>
-        public virtual Task VerifyAttributeAsync(string attributeName, string verificationCode, CancellationToken cancellationToken = default)
+        public virtual Task VerifyAttributeAsync(string attributeName, string verificationCode)
+        {
+            return VerifyAttributeAsync(attributeName, verificationCode, default);
+        }
+
+        /// <summary>
+        /// Verifies the given attribute using an asynchronous call
+        /// </summary>
+        /// <param name="attributeName">Attribute to be verified. Should either be email or phone_number</param>
+        /// <param name="verificationCode">The verification code for the attribute being verified</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual Task VerifyAttributeAsync(string attributeName, string verificationCode, CancellationToken cancellationToken)
         {
             VerifyUserAttributeRequest verifyUserAttributeRequest =
                 CreateVerifyUserAttributeRequest(attributeName, verificationCode);
@@ -300,7 +405,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="attributes">The attributes to be updated</param>
-        public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes, CancellationToken cancellationToken = default)
+        public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes)
+        {
+            await UpdateAttributesAsync(attributes, default);
+        }
+
+        /// <summary>
+        /// Updates the user's attributes defined in the attributes parameter (one at a time)
+        /// using an asynchronous call
+        /// </summary>
+        /// <param name="attributes">The attributes to be updated</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes, CancellationToken cancellationToken)
         {
             UpdateUserAttributesRequest updateUserAttributesRequest =
                 CreateUpdateUserAttributesRequest(attributes);
@@ -319,7 +435,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// an asynchronous call
         /// </summary>
         /// <param name="attributeNamesToDelete">List of attributes to delete</param>
-        public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete, CancellationToken cancellationToken = default)
+        public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
+        {
+            await DeleteAttributesAsync(attributeNamesToDelete, default);
+        }
+
+        /// <summary>
+        /// Deletes the attributes specified in the attributeNamesToDelete list using
+        /// an asynchronous call
+        /// </summary>
+        /// <param name="attributeNamesToDelete">List of attributes to delete</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete, CancellationToken cancellationToken)
         {
             DeleteUserAttributesRequest deleteUserAttributesRequest =
                 CreateDeleteUserAttributesRequest(attributeNamesToDelete);
@@ -341,7 +468,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="userSettings">Dictionary for the user MFA settings of the form [attribute, delivery medium]</param>
-        public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings, CancellationToken cancellationToken = default)
+        public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
+        {
+            await SetUserSettingsAsync(userSettings, default);
+        }
+
+        /// <summary>
+        /// Sets the MFAOptions to be the settings desibed in the userSettings dictionary
+        /// using an asynchronous call
+        /// </summary>
+        /// <param name="userSettings">Dictionary for the user MFA settings of the form [attribute, delivery medium]</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings, CancellationToken cancellationToken)
         {
             SetUserSettingsRequest setUserSettingsRequest = CreateSetUserSettingsRequest(userSettings);
 
@@ -361,7 +499,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <returns>Returns a list of CognitoDevices associated with this user</returns>
         [Obsolete("This method is deprecated since it only lists the first page of devices. The method ListDevicesV2Async should be used instead which allows listing additional pages of devices.")]
-        public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken, CancellationToken cancellationToken = default)
+        public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
+        {
+            return await ListDevicesAsync(limit, paginationToken, default);
+        }
+
+        /// <summary>
+        /// Lists the CognitoDevices associated with this user using an asynchronous call
+        /// </summary>
+        /// <param name="limit">Maxmimum number of devices to be returned in this call</param>
+        /// <param name="paginationToken">Token to continue earlier search</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns a list of CognitoDevices associated with this user</returns>
+        [Obsolete("This method is deprecated since it only lists the first page of devices. The method ListDevicesV2Async should be used instead which allows listing additional pages of devices.")]
+        public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken, CancellationToken cancellationToken)
         {
             ListDevicesRequest listDevicesRequest = CreateListDevicesRequest(limit, paginationToken);
             ListDevicesResponse listDevicesReponse = await Provider.ListDevicesAsync(listDevicesRequest, cancellationToken).ConfigureAwait(false);
@@ -383,7 +534,21 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="limit">Maxmimum number of devices to be returned in this call</param>
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <returns>Returns underlying ListDevicesResponse that contains list of DeviceType objects along with PaginationToken.</returns>
-        public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken, CancellationToken cancellationToken = default)
+        public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken)
+        {
+            return await ListDevicesV2Async(limit, paginationToken, default);
+        }
+
+        /// <summary>
+        /// Executes the ListDevicesAsync service call to access device types associated with this user using an asynchronous call. 
+        /// The response returned contains DeviceType objects which could be used to construct list of CognitoDevice type objects and 
+        /// a PaginationToken which could be used to access remaining device types (if any).
+        /// </summary>
+        /// <param name="limit">Maxmimum number of devices to be returned in this call</param>
+        /// <param name="paginationToken">Token to continue earlier search</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns underlying ListDevicesResponse that contains list of DeviceType objects along with PaginationToken.</returns>
+        public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken, CancellationToken cancellationToken)
         {
             ListDevicesRequest listDevicesRequest = CreateListDevicesRequest(limit, paginationToken);
             return await Provider.ListDevicesAsync(listDevicesRequest, cancellationToken).ConfigureAwait(false);

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -40,7 +40,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for SRP authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
+        {
+            return await StartWithSrpAuthAsync(srpRequest, default);
+        }
+
+        /// <summary>
+        /// Initiates the asynchronous SRP authentication flow
+        /// </summary>
+        /// <param name="srpRequest">InitiateSrpAuthRequest object containing the necessary parameters to
+        /// create an InitiateAuthAsync API call for SRP authentication</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest, CancellationToken cancellationToken)
         {
             if (srpRequest == null || string.IsNullOrEmpty(srpRequest.Password))
             {
@@ -203,7 +216,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for custom authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
+        {
+            return await StartWithCustomAuthAsync(customRequest, default);
+        }
+
+        /// <summary>
+        /// Initiates the asynchronous custom authentication flow
+        /// </summary>
+        /// <param name="customRequest">InitiateCustomAuthRequest object containing the necessary parameters to
+        /// create an InitiateAuthAsync API call for custom authentication</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest, CancellationToken cancellationToken)
         {
             InitiateAuthRequest authRequest = new InitiateAuthRequest()
             {
@@ -233,7 +259,21 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current custom authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
+        {
+            return await RespondToCustomAuthAsync(customRequest, default);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToCustomChallengeRequest object to respond to the current 
+        /// custom authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="customRequest">RespondToCustomChallengeRequest object containing the necessary parameters to
+        /// respond to the current custom authentication challenge</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest, CancellationToken cancellationToken)
         {
             RespondToAuthChallengeRequest request = new RespondToAuthChallengeRequest()
             {
@@ -277,7 +317,22 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="passwordVerifier">The password verifier generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
         /// <param name="salt">The salt generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
         /// <returns></returns>
-        public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt, CancellationToken cancellationToken = default)
+        public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt)
+        {
+            return await ConfirmDeviceAsync(accessToken, deviceKey, deviceName, passwordVerifier, salt, default);
+        }
+
+        /// <summary>
+        /// Sends a confirmation request to Cognito for a new CognitoDevice
+        /// </summary>
+        /// <param name="accessToken">The user pool access token for from the InitiateAuth or other challenge response</param>
+        /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
+        /// <param name="deviceName">The friendly name to be associated with the corresponding CognitoDevice</param>
+        /// <param name="passwordVerifier">The password verifier generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
+        /// <param name="salt">The salt generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns></returns>
+        public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt, CancellationToken cancellationToken)
         {
             var request = new ConfirmDeviceRequest
             {
@@ -301,7 +356,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
         /// <param name="deviceRememberedStatus">The device remembered status for the associated CognitoDevice</param>
         /// <returns></returns>
-        public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus, CancellationToken cancellationToken = default)
+        public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus)
+        {
+            return await UpdateDeviceStatusAsync(accessToken, deviceKey, deviceRememberedStatus, default);
+        }
+
+        /// <summary>
+        /// Updates the remembered status for a given CognitoDevice
+        /// </summary>
+        /// <param name="accessToken">The user pool access token for from the InitiateAuth or other challenge response</param>
+        /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
+        /// <param name="deviceRememberedStatus">The device remembered status for the associated CognitoDevice</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns></returns>
+        public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus, CancellationToken cancellationToken)
         {
             var request = new UpdateDeviceStatusRequest
             {
@@ -312,7 +380,6 @@ namespace Amazon.Extensions.CognitoAuthentication
 
             return await Provider.UpdateDeviceStatusAsync(request, cancellationToken);
         }
-
         /// <summary>
         /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
         /// authentication challenge using an asynchronous call
@@ -321,7 +388,21 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
+        {
+            return await RespondToSmsMfaAuthAsync(smsMfaRequest, default);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
+        /// authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="smsMfaRequest">RespondToSmsMfaRequest object containing the necessary parameters to
+        /// respond to the current SMS MFA authentication challenge</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest, CancellationToken cancellationToken)
         {
             return await RespondToMfaAuthAsync(smsMfaRequest, cancellationToken).ConfigureAwait(false);
         }
@@ -334,7 +415,21 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest, CancellationToken cancellationToken = default)
+        public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest)
+        {
+            return await RespondToMfaAuthAsync(mfaRequest, default);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
+        /// authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="mfaRequest">RespondToMfaRequest object containing the necessary parameters to
+        /// respond to the current MFA authentication challenge</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest, CancellationToken cancellationToken)
         {
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {
@@ -386,7 +481,21 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, CancellationToken cancellationToken = default)
+        public virtual Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest)
+        {
+            return RespondToNewPasswordRequiredAsync(newPasswordRequest, null, default);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToNewPasswordRequiredRequest object to respond to the current new 
+        /// password required authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
+        /// parameters to respond to the current SMS MFA authentication challenge</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, CancellationToken cancellationToken)
         {
             return RespondToNewPasswordRequiredAsync(newPasswordRequest, null, cancellationToken);
         }
@@ -401,7 +510,23 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
+        {
+            return await RespondToNewPasswordRequiredAsync(newPasswordRequest, requiredAttributes, default);
+        }
+
+        /// <summary>
+        /// Uses the properties of the RespondToNewPasswordRequiredRequest object to respond to the current new 
+        /// password required authentication challenge using an asynchronous call
+        /// </summary>
+        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
+        /// <param name="requiredAttributes">Optional dictionnary of attributes that may be required by the user pool
+        /// Each attribute key must be prefixed by "userAttributes."
+        /// parameters to respond to the current SMS MFA authentication challenge</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes, CancellationToken cancellationToken)
         {
             var challengeResponses = new Dictionary<string, string>()
             {
@@ -450,7 +575,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the refresh token authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
+        {
+            return await StartWithRefreshTokenAuthAsync(refreshTokenRequest, default);
+        }
+
+        /// <summary>
+        /// Initiates the asynchronous refresh token authentication flow
+        /// </summary>
+        /// <param name="refreshTokenRequest">InitiateRefreshTokenAuthRequest object containing the necessary 
+        /// parameters to initiate the refresh token authentication flow</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest, CancellationToken cancellationToken)
         {
             InitiateAuthRequest initiateAuthRequest = CreateRefreshTokenAuthRequest(refreshTokenRequest.AuthFlowType);
 
@@ -477,7 +615,20 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the ADMIN_NO_SRP_AUTH authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
+        {
+            return await StartWithAdminNoSrpAuthAsync(adminAuthRequest, default);
+        }
+
+        /// <summary>
+        /// Initiates the asynchronous ADMIN_NO_SRP_AUTH authentication flow
+        /// </summary>
+        /// <param name="adminAuthRequest">InitiateAdminNoSrpAuthRequest object containing the necessary 
+        /// parameters to initiate the ADMIN_NO_SRP_AUTH authentication flow</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
+        /// if one exists</returns>
+        public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest, CancellationToken cancellationToken)
         {
             AdminInitiateAuthRequest initiateAuthRequest = CreateAdminAuthRequest(adminAuthRequest);
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -88,8 +88,25 @@ namespace Amazon.Extensions.CognitoAuthentication
         public Task SignUpAsync(string userID,
                            string password,
                            IDictionary<string, string> userAttributes,
+                           IDictionary<string, string> validationData)
+        {
+            return SignUpAsync(userID, password, userAttributes, validationData, default);
+        }
+
+        /// <summary>
+        /// Signs up the user with the specified parameters using an asynchronous call
+        /// </summary>
+        /// <param name="userID">The userID of the user being created</param>
+        /// <param name="password">The password of the user being created</param>
+        /// <param name="userAttributes">The user attributes of the user being created</param>
+        /// <param name="validationData">The validation data of the user being created</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the delivery details for the sign up request</returns>
+        public Task SignUpAsync(string userID,
+                           string password,
+                           IDictionary<string, string> userAttributes,
                            IDictionary<string, string> validationData,
-                           CancellationToken cancellationToken = default)
+                           CancellationToken cancellationToken)
         {
             SignUpRequest signUpUserRequest = CreateSignUpRequest(userID, password, userAttributes, validationData);
 
@@ -186,7 +203,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="userID">The userID of the corresponding user</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
-        public virtual async Task<CognitoUser> FindByIdAsync(string userID, CancellationToken cancellationToken = default)
+        public virtual async Task<CognitoUser> FindByIdAsync(string userID)
+        {
+            return await FindByIdAsync(userID, default);
+        }
+
+        /// <summary>
+        /// Queries Cognito and returns the CognitoUser with the corresponding userID
+        /// </summary>
+        /// <param name="userID">The userID of the corresponding user</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
+        public virtual async Task<CognitoUser> FindByIdAsync(string userID, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(userID))
                 throw new ArgumentException(nameof(userID));
@@ -214,7 +242,17 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Queries Cognito and returns the PasswordPolicyType associated with the pool.
         /// </summary>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
-        public async Task<PasswordPolicyType> GetPasswordPolicyTypeAsync(CancellationToken cancellationToken = default)
+        public async Task<PasswordPolicyType> GetPasswordPolicyTypeAsync()
+        {
+            return await GetPasswordPolicyTypeAsync(default);
+        }
+
+        /// <summary>
+        /// Queries Cognito and returns the PasswordPolicyType associated with the pool.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
+        public async Task<PasswordPolicyType> GetPasswordPolicyTypeAsync(CancellationToken cancellationToken)
         {
             var response = await Provider.DescribeUserPoolAsync(new DescribeUserPoolRequest
             {
@@ -229,7 +267,18 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Caches the value in the ClientConfiguration private property.
         /// </summary>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
-        public async Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration(CancellationToken cancellationToken = default)
+        public async Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration()
+        {
+            return await GetUserPoolClientConfiguration(default);
+        }
+
+        /// <summary>
+        /// Queries Cognito and returns the CognitoUserPoolClientConfiguration associated with the current pool client.
+        /// Caches the value in the ClientConfiguration private property.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
+        public async Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration(CancellationToken cancellationToken)
         {
             if (ClientConfiguration == null)
             {
@@ -254,8 +303,23 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>Returns the delivery details for the sign up request</returns>
         public Task AdminSignupAsync(string userID,
                            IDictionary<string, string> userAttributes,
+                           IDictionary<string, string> validationData)
+        {
+            return AdminSignupAsync(userID, userAttributes, validationData, default);
+        }
+
+        /// <summary>
+        /// Signs up the user with the specified parameters using an asynchronous call end triggers a temporary password sms or email message.
+        /// </summary>
+        /// <param name="userID">The userID of the user being created</param>
+        /// <param name="userAttributes">The user attributes of the user being created</param>
+        /// <param name="validationData">The validation data of the user being created</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
+        /// <returns>Returns the delivery details for the sign up request</returns>
+        public Task AdminSignupAsync(string userID,
+                           IDictionary<string, string> userAttributes,
                            IDictionary<string, string> validationData,
-                           CancellationToken cancellationToken = default)
+                           CancellationToken cancellationToken)
         {
             AdminCreateUserRequest signUpUserRequest = CreateAdminSignUpRequest(userID, userAttributes, validationData);
 


### PR DESCRIPTION
*Issue #, if available:* #119

*Description of changes:* PR #115 added cancellation tokens with defaults, but this breaks existing callers who do not recompile.

This adds back the previous signatures, calling into the new ones with a `default` token.

I built locally with this added to the csproj, no new errors (outside of the expected one due to the snk difference):
```
	  <EnablePackageValidation>true</EnablePackageValidation>
	  <PackageValidationBaselineVersion>2.4.0</PackageValidationBaselineVersion>
```

You can view the diff from 2.4.0 to 2.4.2 at https://github.com/aws/aws-sdk-net-extensions-cognito/compare/4e9f2fa...1f63d79?diff=split

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
