### PR TITLE
CognitoUser.SecretHash initialization fix

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -123,13 +123,8 @@ namespace Amazon.Extensions.CognitoAuthentication
             }
 
             this.ClientSecret = clientSecret;
-            if (!string.IsNullOrEmpty(clientSecret))
-            {
-                this.SecretHash = CognitoAuthHelper.GetUserPoolSecretHash(userID, clientID, clientSecret);
-            }
 
             this.UserID = userID;
-            this.Username = userID;
             if (!string.IsNullOrEmpty(username))
             {
                 this.Username = username;
@@ -137,6 +132,11 @@ namespace Amazon.Extensions.CognitoAuthentication
             else
             {
                 this.Username = userID;
+            }
+
+            if (!string.IsNullOrEmpty(clientSecret))
+            {
+                this.SecretHash = CognitoAuthHelper.GetUserPoolSecretHash(Username, clientID, clientSecret);
             }
 
             this.Status = status;

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -66,7 +66,7 @@ namespace Amazon.Extensions.CognitoAuthentication
             if (srpRequest.IsCustomAuthFlow)
             {
                 initiateRequest.AuthFlow = AuthFlowType.CUSTOM_AUTH;
-                initiateRequest.AuthParameters.Add("CHALLENGE_NAME", "SRP_A");
+                initiateRequest.AuthParameters.Add(CognitoConstants.ChlgParamChallengeName, CognitoConstants.ChlgParamSrpA);
             }
             InitiateAuthResponse initiateResponse = await Provider.InitiateAuthAsync(initiateRequest, cancellationToken).ConfigureAwait(false);
             UpdateUsernameAndSecretHash(initiateResponse.ChallengeParameters);
@@ -132,7 +132,7 @@ namespace Amazon.Extensions.CognitoAuthentication
             
             RespondToAuthChallengeRequest authChallengeRequest = new RespondToAuthChallengeRequest()
             {
-                ChallengeName = "DEVICE_SRP_AUTH",
+                ChallengeName = ChallengeNameType.DEVICE_SRP_AUTH,
                 ClientId = ClientID,
                 Session = challenge.Session,
                 ChallengeResponses = new Dictionary<string, string>
@@ -143,9 +143,8 @@ namespace Amazon.Extensions.CognitoAuthentication
                 }
 
             };
-            if (!string.IsNullOrEmpty(ClientSecret))
+            if (!string.IsNullOrEmpty(SecretHash))
             {
-                SecretHash = CognitoAuthHelper.GetUserPoolSecretHash(Username, ClientID, ClientSecret);
                 authChallengeRequest.ChallengeResponses.Add(CognitoConstants.ChlgParamSecretHash, SecretHash);
             }
             return authChallengeRequest;
@@ -192,9 +191,8 @@ namespace Amazon.Extensions.CognitoAuthentication
                 {CognitoConstants.ChlgParamDeviceKey, Device.DeviceKey }
             };
 
-            if (!string.IsNullOrEmpty(ClientSecret))
+            if (!string.IsNullOrEmpty(SecretHash))
             {
-                SecretHash = CognitoAuthHelper.GetUserPoolSecretHash(Username, ClientID, ClientSecret);
                 srpAuthResponses.Add(CognitoConstants.ChlgParamSecretHash, SecretHash);
             }
 
@@ -814,9 +812,8 @@ namespace Amazon.Extensions.CognitoAuthentication
                 {CognitoConstants.ChlgParamTimestamp, timeStr },
             };
 
-            if (!string.IsNullOrEmpty(ClientSecret))
+            if (!string.IsNullOrEmpty(SecretHash))
             {
-                SecretHash = CognitoAuthHelper.GetUserPoolSecretHash(Username, ClientID, ClientSecret);
                 srpAuthResponses.Add(CognitoConstants.ChlgParamSecretHash, SecretHash);
             }
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -672,10 +672,9 @@ namespace Amazon.Extensions.CognitoAuthentication
                 }
             };
 
-            if (!string.IsNullOrEmpty(ClientSecret))
+            if (!string.IsNullOrEmpty(SecretHash))
             {
-                initiateAuthRequest.AuthParameters.Add(CognitoConstants.ChlgParamSecretHash,
-                                                    CognitoAuthHelper.GetUserPoolSecretHash(Username, ClientID, ClientSecret));
+                initiateAuthRequest.AuthParameters.Add(CognitoConstants.ChlgParamSecretHash, SecretHash);
             }
 
             if (Device != null && !string.IsNullOrEmpty(Device.DeviceKey))


### PR DESCRIPTION
Hello everyone!
I want to change order of initialization of SecretHash property in CognitoUser ctor. If i pass valid username to CognitoUser ctor, it will be ignored because of order of assignment. My changes helps create SecretHash in ctor if valid username provided. It fixes issue, when i create CognitoUser with valid username and call StartWithRefreshTokenAuthAsync. It fails because UserId used instead of Username for SecretHash calculation.

Username changes only in two palces: [CognitoUser ctor](https://github.com/aws/aws-sdk-net-extensions-cognito/blob/143cdfbea86a9ef4e77eec5590685a0999e7000f/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs#L132C16-L132C16) and [UpdateUsernameAndSecretHash](https://github.com/aws/aws-sdk-net-extensions-cognito/blob/143cdfbea86a9ef4e77eec5590685a0999e7000f/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs#L708C21-L708C21). ClientId and ClientSecret properties has private setters and can't be changed outside of class. So, i replace SecretHash recalculation to it direct usage.

Also, i replace raw string to usage of CognitoConstants & ChallengeNameType class properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
