### PR TITLE
ChallengeName check and small improvements

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -434,10 +434,6 @@ namespace Amazon.Extensions.CognitoAuthentication
             {
                 throw new ArgumentNullException(nameof(mfaRequest));
             }
-            if (mfaRequest.ChallengeNameType != ChallengeNameType.SMS_MFA && mfaRequest.ChallengeNameType != ChallengeNameType.SOFTWARE_TOKEN_MFA)
-            {
-                throw new ArgumentException($"{ChallengeNameType.SMS_MFA} or {ChallengeNameType.SOFTWARE_TOKEN_MFA} at {nameof(mfaRequest.ChallengeNameType)} required.", nameof(mfaRequest));
-            }
 
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -57,7 +57,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if (srpRequest == null || string.IsNullOrEmpty(srpRequest.Password))
             {
-                throw new ArgumentNullException("Password required for authentication.", "srpRequest");
+                throw new ArgumentNullException(nameof(srpRequest), "Password required for authentication.");
             }
 
             Tuple<BigInteger, BigInteger> tupleAa = AuthenticationHelper.CreateAaTuple();
@@ -89,14 +89,13 @@ namespace Amazon.Extensions.CognitoAuthentication
 
             RespondToAuthChallengeResponse verifierResponse =
                 await Provider.RespondToAuthChallengeAsync(challengeRequest, cancellationToken).ConfigureAwait(false);
-            var isDeviceAuthRequest = verifierResponse.AuthenticationResult == null && (!string.IsNullOrEmpty(srpRequest.DeviceGroupKey)
-                || !string.IsNullOrEmpty(srpRequest.DevicePass));
+
             #region Device-level authentication
-            if (isDeviceAuthRequest)
+            if (verifierResponse.ChallengeName == ChallengeNameType.DEVICE_SRP_AUTH)
             {
                 if (string.IsNullOrEmpty(srpRequest.DeviceGroupKey) || string.IsNullOrEmpty(srpRequest.DevicePass))
                 {
-                    throw new ArgumentNullException("Device Group Key and Device Pass required for authentication.", "srpRequest");
+                    throw new ArgumentNullException(nameof(srpRequest), $"{nameof(srpRequest.DeviceGroupKey)} and {nameof(srpRequest.DevicePass)} required for authentication with challenge {ChallengeNameType.DEVICE_SRP_AUTH}");
                 }
 
                 #region Device SRP Auth
@@ -431,6 +430,15 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest, CancellationToken cancellationToken)
         {
+            if (mfaRequest == null)
+            {
+                throw new ArgumentNullException(nameof(mfaRequest));
+            }
+            if (mfaRequest.ChallengeNameType != ChallengeNameType.SMS_MFA && mfaRequest.ChallengeNameType != ChallengeNameType.SOFTWARE_TOKEN_MFA)
+            {
+                throw new ArgumentException($"{ChallengeNameType.SMS_MFA} or {ChallengeNameType.SOFTWARE_TOKEN_MFA} at {nameof(mfaRequest.ChallengeNameType)} required.", nameof(mfaRequest));
+            }
+
             RespondToAuthChallengeRequest challengeRequest = new RespondToAuthChallengeRequest
             {
                 ChallengeResponses = new Dictionary<string, string>


### PR DESCRIPTION
Hello. I add explicit check for DEVICE_SRP_AUTH challenge name in StartWithSrpAuthAsync method. It fix issue, when cognito return SOFTWARE_TOKEN_MFA challenge and reqeust parameter initialized with valid device properties.

I change order of parameters in some exceptions ctors(param name and message has wrong positions); use nameof() instead of parameter name as string; request parameter validation to RespondToMfaAuthAsync method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
