### PR TITLE
#129 - Fix StartWithSrpAuthAsync called by Sync context

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -28,7 +28,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
@@ -158,7 +158,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         public async Task GetDeviceAsync()
         {
-            await GetDeviceAsync(default);
+            await GetDeviceAsync(default).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -407,7 +407,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="attributes">The attributes to be updated</param>
         public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes)
         {
-            await UpdateAttributesAsync(attributes, default);
+            await UpdateAttributesAsync(attributes, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -437,7 +437,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="attributeNamesToDelete">List of attributes to delete</param>
         public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
         {
-            await DeleteAttributesAsync(attributeNamesToDelete, default);
+            await DeleteAttributesAsync(attributeNamesToDelete, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -470,7 +470,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="userSettings">Dictionary for the user MFA settings of the form [attribute, delivery medium]</param>
         public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
         {
-            await SetUserSettingsAsync(userSettings, default);
+            await SetUserSettingsAsync(userSettings, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         [Obsolete("This method is deprecated since it only lists the first page of devices. The method ListDevicesV2Async should be used instead which allows listing additional pages of devices.")]
         public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
         {
-            return await ListDevicesAsync(limit, paginationToken, default);
+            return await ListDevicesAsync(limit, paginationToken, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -536,7 +536,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>Returns underlying ListDevicesResponse that contains list of DeviceType objects along with PaginationToken.</returns>
         public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken)
         {
-            return await ListDevicesV2Async(limit, paginationToken, default);
+            return await ListDevicesV2Async(limit, paginationToken, default).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -218,7 +218,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
         {
-            return await StartWithCustomAuthAsync(customRequest, default);
+            return await StartWithCustomAuthAsync(customRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
         {
-            return await RespondToCustomAuthAsync(customRequest, default);
+            return await RespondToCustomAuthAsync(customRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns></returns>
         public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt)
         {
-            return await ConfirmDeviceAsync(accessToken, deviceKey, deviceName, passwordVerifier, salt, default);
+            return await ConfirmDeviceAsync(accessToken, deviceKey, deviceName, passwordVerifier, salt, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 }
             };
 
-            return await Provider.ConfirmDeviceAsync(request, cancellationToken);
+            return await Provider.ConfirmDeviceAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns></returns>
         public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus)
         {
-            return await UpdateDeviceStatusAsync(accessToken, deviceKey, deviceRememberedStatus, default);
+            return await UpdateDeviceStatusAsync(accessToken, deviceKey, deviceRememberedStatus, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 DeviceRememberedStatus = deviceRememberedStatus
             };
 
-            return await Provider.UpdateDeviceStatusAsync(request, cancellationToken);
+            return await Provider.UpdateDeviceStatusAsync(request, cancellationToken).ConfigureAwait(false);
         }
         /// <summary>
         /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
@@ -390,7 +390,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
         {
-            return await RespondToSmsMfaAuthAsync(smsMfaRequest, default);
+            return await RespondToSmsMfaAuthAsync(smsMfaRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest)
         {
-            return await RespondToMfaAuthAsync(mfaRequest, default);
+            return await RespondToMfaAuthAsync(mfaRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
         {
-            return await RespondToNewPasswordRequiredAsync(newPasswordRequest, requiredAttributes, default);
+            return await RespondToNewPasswordRequiredAsync(newPasswordRequest, requiredAttributes, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -577,7 +577,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
         {
-            return await StartWithRefreshTokenAuthAsync(refreshTokenRequest, default);
+            return await StartWithRefreshTokenAuthAsync(refreshTokenRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -617,7 +617,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
         {
-            return await StartWithAdminNoSrpAuthAsync(adminAuthRequest, default);
+            return await StartWithAdminNoSrpAuthAsync(adminAuthRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -42,7 +42,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// if one exists</returns>
         public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
         {
-            return await StartWithSrpAuthAsync(srpRequest, default);
+            return await StartWithSrpAuthAsync(srpRequest, default).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -205,7 +205,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
         public virtual async Task<CognitoUser> FindByIdAsync(string userID)
         {
-            return await FindByIdAsync(userID, default);
+            return await FindByIdAsync(userID, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -244,7 +244,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
         public async Task<PasswordPolicyType> GetPasswordPolicyTypeAsync()
         {
-            return await GetPasswordPolicyTypeAsync(default);
+            return await GetPasswordPolicyTypeAsync(default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -269,7 +269,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
         public async Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration()
         {
-            return await GetUserPoolClientConfiguration(default);
+            return await GetUserPoolClientConfiguration(default).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
@@ -65,7 +65,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             {
                 SessionID = context.SessionID,
                 NewPassword = "NewPassword1!"
-            });
+            }).ConfigureAwait(false);
 
             Assert.True(user.SessionTokens.IsValid());
         }

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
@@ -51,7 +51,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
            {
                MfaCode = "fakeMfaCode",
                SessionID = context.SessionID
-           }));
+           })).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
@@ -28,7 +28,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
         [Fact]
         public async void TestFailedChangePassword()
         {
-            await Assert.ThrowsAsync<NotAuthorizedException>(() => user.ChangePasswordAsync("PassWord1!", "PassWord2!"));
+            await Assert.ThrowsAsync<NotAuthorizedException>(() => user.ChangePasswordAsync("PassWord1!", "PassWord2!")).ConfigureAwait(false);
         }
 
         // Tests that a CognitoUser object has a valid session object after being authenticated


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/129

*Description of changes:*
Fixed bug with StartWithSrpAuthAsync(InitiateSrpAuthRequest) that would result in a deadlock scenario if the method was called by a synchronous context (e.g. .Result called on the method).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
