### PR TITLE
#129 - Fix StartWithSrpAuthAsync called by Sync context

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -28,7 +28,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <DelaySign>false</DelaySign>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
   </PropertyGroup>
 
   <Choose>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
@@ -156,9 +156,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Gets the device from the Cognito service using the device key and user's access 
         /// token using an asynchronous call
         /// </summary>
-        public async Task GetDeviceAsync()
+        public Task GetDeviceAsync()
         {
-            await GetDeviceAsync(default);
+            return GetDeviceAsync(default);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -405,9 +405,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="attributes">The attributes to be updated</param>
-        public virtual async Task UpdateAttributesAsync(IDictionary<string, string> attributes)
+        public virtual Task UpdateAttributesAsync(IDictionary<string, string> attributes)
         {
-            await UpdateAttributesAsync(attributes, default);
+            return UpdateAttributesAsync(attributes, default);
         }
 
         /// <summary>
@@ -435,9 +435,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// an asynchronous call
         /// </summary>
         /// <param name="attributeNamesToDelete">List of attributes to delete</param>
-        public virtual async Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
+        public virtual Task DeleteAttributesAsync(IList<string> attributeNamesToDelete)
         {
-            await DeleteAttributesAsync(attributeNamesToDelete, default);
+            return DeleteAttributesAsync(attributeNamesToDelete, default);
         }
 
         /// <summary>
@@ -468,9 +468,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// using an asynchronous call
         /// </summary>
         /// <param name="userSettings">Dictionary for the user MFA settings of the form [attribute, delivery medium]</param>
-        public virtual async Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
+        public virtual Task SetUserSettingsAsync(IDictionary<string, string> userSettings)
         {
-            await SetUserSettingsAsync(userSettings, default);
+            return SetUserSettingsAsync(userSettings, default);
         }
 
         /// <summary>
@@ -499,9 +499,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <returns>Returns a list of CognitoDevices associated with this user</returns>
         [Obsolete("This method is deprecated since it only lists the first page of devices. The method ListDevicesV2Async should be used instead which allows listing additional pages of devices.")]
-        public virtual async Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
+        public virtual Task<List<CognitoDevice>> ListDevicesAsync(int limit, string paginationToken)
         {
-            return await ListDevicesAsync(limit, paginationToken, default);
+            return ListDevicesAsync(limit, paginationToken, default);
         }
 
         /// <summary>
@@ -534,9 +534,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="limit">Maxmimum number of devices to be returned in this call</param>
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <returns>Returns underlying ListDevicesResponse that contains list of DeviceType objects along with PaginationToken.</returns>
-        public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken)
+        public virtual Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken)
         {
-            return await ListDevicesV2Async(limit, paginationToken, default);
+            return ListDevicesV2Async(limit, paginationToken, default);
         }
 
         /// <summary>
@@ -548,10 +548,10 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="paginationToken">Token to continue earlier search</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns>Returns underlying ListDevicesResponse that contains list of DeviceType objects along with PaginationToken.</returns>
-        public virtual async Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken, CancellationToken cancellationToken)
+        public virtual Task<ListDevicesResponse> ListDevicesV2Async(int limit, string paginationToken, CancellationToken cancellationToken)
         {
             ListDevicesRequest listDevicesRequest = CreateListDevicesRequest(limit, paginationToken);
-            return await Provider.ListDevicesAsync(listDevicesRequest, cancellationToken).ConfigureAwait(false);
+            return Provider.ListDevicesAsync(listDevicesRequest, cancellationToken);
         }
 
         /// <summary>
@@ -559,7 +559,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns><see cref="AssociateSoftwareTokenResponse"/> with secret code.</returns>
-        public virtual async Task<AssociateSoftwareTokenResponse> AssociateSoftwareTokenAsync(CancellationToken cancellationToken)
+        public virtual Task<AssociateSoftwareTokenResponse> AssociateSoftwareTokenAsync(CancellationToken cancellationToken)
         {
             EnsureUserAuthenticated();
 
@@ -568,7 +568,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 AccessToken = SessionTokens.AccessToken
             };
 
-            return await Provider.AssociateSoftwareTokenAsync(request, cancellationToken).ConfigureAwait(false);
+            return Provider.AssociateSoftwareTokenAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -577,7 +577,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="code">Code from authenticator app.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns><see cref="VerifySoftwareTokenResponse"/> which contains token verification status.</returns>
-        public virtual async Task<VerifySoftwareTokenResponse> VerifySoftwareTokenAsync(string code, CancellationToken cancellationToken) {
+        public virtual Task<VerifySoftwareTokenResponse> VerifySoftwareTokenAsync(string code, CancellationToken cancellationToken) {
             if (string.IsNullOrEmpty(code))
                 throw new ArgumentNullException(nameof(code));
 
@@ -589,7 +589,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 UserCode = code
             };
 
-            return await Provider.VerifySoftwareTokenAsync(request, cancellationToken).ConfigureAwait(false);
+            return Provider.VerifySoftwareTokenAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -599,7 +599,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="isEnabled">Enable or disable software MFA.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns></returns>
-        public async Task UpdateSoftwareMfaSettingsAsync(bool isPreferred, bool isEnabled, CancellationToken cancellationToken)
+        public Task UpdateSoftwareMfaSettingsAsync(bool isPreferred, bool isEnabled, CancellationToken cancellationToken)
         {
             EnsureUserAuthenticated();
             SetUserMFAPreferenceRequest request = new SetUserMFAPreferenceRequest {
@@ -610,7 +610,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 }
             };
 
-            await Provider.SetUserMFAPreferenceAsync(request, cancellationToken).ConfigureAwait(false);
+            return Provider.SetUserMFAPreferenceAsync(request, cancellationToken);
         }
 
         private ConfirmSignUpRequest CreateConfirmSignUpRequest(string confirmationCode, bool forcedAliasCreation)

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -40,9 +40,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for SRP authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
+        public virtual Task<AuthFlowResponse> StartWithSrpAuthAsync(InitiateSrpAuthRequest srpRequest)
         {
-            return await StartWithSrpAuthAsync(srpRequest, default);
+            return StartWithSrpAuthAsync(srpRequest, default);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -216,9 +216,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// create an InitiateAuthAsync API call for custom authentication</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
+        public virtual Task<AuthFlowResponse> StartWithCustomAuthAsync(InitiateCustomAuthRequest customRequest)
         {
-            return await StartWithCustomAuthAsync(customRequest, default);
+            return StartWithCustomAuthAsync(customRequest, default);
         }
 
         /// <summary>
@@ -259,9 +259,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current custom authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
+        public virtual Task<AuthFlowResponse> RespondToCustomAuthAsync(RespondToCustomChallengeRequest customRequest)
         {
-            return await RespondToCustomAuthAsync(customRequest, default);
+            return RespondToCustomAuthAsync(customRequest, default);
         }
 
         /// <summary>
@@ -317,9 +317,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="passwordVerifier">The password verifier generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
         /// <param name="salt">The salt generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
         /// <returns></returns>
-        public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt)
+        public Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt)
         {
-            return await ConfirmDeviceAsync(accessToken, deviceKey, deviceName, passwordVerifier, salt, default);
+            return ConfirmDeviceAsync(accessToken, deviceKey, deviceName, passwordVerifier, salt, default);
         }
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="salt">The salt generated from GenerateDeviceVerifier for the corresponding CognitoDevice</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns></returns>
-        public async Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt, CancellationToken cancellationToken)
+        public Task<ConfirmDeviceResponse> ConfirmDeviceAsync(string accessToken, string deviceKey, string deviceName, string passwordVerifier, string salt, CancellationToken cancellationToken)
         {
             var request = new ConfirmDeviceRequest
             {
@@ -346,7 +346,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 }
             };
 
-            return await Provider.ConfirmDeviceAsync(request, cancellationToken);
+            return Provider.ConfirmDeviceAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -356,9 +356,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="deviceKey">The device key for the associated CognitoDevice</param>
         /// <param name="deviceRememberedStatus">The device remembered status for the associated CognitoDevice</param>
         /// <returns></returns>
-        public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus)
+        public Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus)
         {
-            return await UpdateDeviceStatusAsync(accessToken, deviceKey, deviceRememberedStatus, default);
+            return UpdateDeviceStatusAsync(accessToken, deviceKey, deviceRememberedStatus, default);
         }
 
         /// <summary>
@@ -369,7 +369,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="deviceRememberedStatus">The device remembered status for the associated CognitoDevice</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns></returns>
-        public async Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus, CancellationToken cancellationToken)
+        public Task<UpdateDeviceStatusResponse> UpdateDeviceStatusAsync(string accessToken, string deviceKey, string deviceRememberedStatus, CancellationToken cancellationToken)
         {
             var request = new UpdateDeviceStatusRequest
             {
@@ -378,7 +378,7 @@ namespace Amazon.Extensions.CognitoAuthentication
                 DeviceRememberedStatus = deviceRememberedStatus
             };
 
-            return await Provider.UpdateDeviceStatusAsync(request, cancellationToken);
+            return Provider.UpdateDeviceStatusAsync(request, cancellationToken);
         }
         /// <summary>
         /// Uses the properties of the RespondToSmsMfaRequest object to respond to the current MFA 
@@ -388,9 +388,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
+        public virtual Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest)
         {
-            return await RespondToSmsMfaAuthAsync(smsMfaRequest, default);
+            return RespondToSmsMfaAuthAsync(smsMfaRequest, default);
         }
 
         /// <summary>
@@ -402,9 +402,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest, CancellationToken cancellationToken)
+        public virtual Task<AuthFlowResponse> RespondToSmsMfaAuthAsync(RespondToSmsMfaRequest smsMfaRequest, CancellationToken cancellationToken)
         {
-            return await RespondToMfaAuthAsync(smsMfaRequest, cancellationToken).ConfigureAwait(false);
+            return RespondToMfaAuthAsync(smsMfaRequest, cancellationToken);
         }
 
         /// <summary>
@@ -415,9 +415,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// respond to the current MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public async Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest)
+        public Task<AuthFlowResponse> RespondToMfaAuthAsync(RespondToMfaRequest mfaRequest)
         {
-            return await RespondToMfaAuthAsync(mfaRequest, default);
+            return RespondToMfaAuthAsync(mfaRequest, default);
         }
 
         /// <summary>
@@ -510,9 +510,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
+        public virtual Task<AuthFlowResponse> RespondToNewPasswordRequiredAsync(RespondToNewPasswordRequiredRequest newPasswordRequest, Dictionary<string, string> requiredAttributes)
         {
-            return await RespondToNewPasswordRequiredAsync(newPasswordRequest, requiredAttributes, default);
+            return RespondToNewPasswordRequiredAsync(newPasswordRequest, requiredAttributes, default);
         }
 
         /// <summary>
@@ -575,9 +575,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the refresh token authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
+        public virtual Task<AuthFlowResponse> StartWithRefreshTokenAuthAsync(InitiateRefreshTokenAuthRequest refreshTokenRequest)
         {
-            return await StartWithRefreshTokenAuthAsync(refreshTokenRequest, default);
+            return StartWithRefreshTokenAuthAsync(refreshTokenRequest, default);
         }
 
         /// <summary>
@@ -615,9 +615,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// parameters to initiate the ADMIN_NO_SRP_AUTH authentication flow</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
         /// if one exists</returns>
-        public virtual async Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
+        public virtual Task<AuthFlowResponse> StartWithAdminNoSrpAuthAsync(InitiateAdminNoSrpAuthRequest adminAuthRequest)
         {
-            return await StartWithAdminNoSrpAuthAsync(adminAuthRequest, default);
+            return StartWithAdminNoSrpAuthAsync(adminAuthRequest, default);
         }
 
         /// <summary>

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -203,9 +203,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// </summary>
         /// <param name="userID">The userID of the corresponding user</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a CognitoUser with the corresponding userID, with the Status and Attributes retrieved from Cognito.</returns>
-        public virtual async Task<CognitoUser> FindByIdAsync(string userID)
+        public virtual Task<CognitoUser> FindByIdAsync(string userID)
         {
-            return await FindByIdAsync(userID, default);
+            return FindByIdAsync(userID, default);
         }
 
         /// <summary>
@@ -242,9 +242,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Queries Cognito and returns the PasswordPolicyType associated with the pool.
         /// </summary>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
-        public async Task<PasswordPolicyType> GetPasswordPolicyTypeAsync()
+        public Task<PasswordPolicyType> GetPasswordPolicyTypeAsync()
         {
-            return await GetPasswordPolicyTypeAsync(default);
+            return GetPasswordPolicyTypeAsync(default);
         }
 
         /// <summary>
@@ -267,9 +267,9 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Caches the value in the ClientConfiguration private property.
         /// </summary>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the PasswordPolicyType of the pool.</returns>
-        public async Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration()
+        public Task<CognitoUserPoolClientConfiguration> GetUserPoolClientConfiguration()
         {
-            return await GetUserPoolClientConfiguration(default);
+            return GetUserPoolClientConfiguration(default);
         }
 
         /// <summary>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
@@ -65,7 +65,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             {
                 SessionID = context.SessionID,
                 NewPassword = "NewPassword1!"
-            });
+            }).ConfigureAwait(false);
 
             Assert.True(user.SessionTokens.IsValid());
         }

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
@@ -51,7 +51,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
            {
                MfaCode = "fakeMfaCode",
                SessionID = context.SessionID
-           }));
+           })).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
@@ -26,9 +26,9 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
     {
         // Tests the ChangePassword method in CognitoUser to fail due to no valid session
         [Fact]
-        public async void TestFailedChangePassword()
+        public Task TestFailedChangePassword()
         {
-            await Assert.ThrowsAsync<NotAuthorizedException>(() => user.ChangePasswordAsync("PassWord1!", "PassWord2!"));
+            return Assert.ThrowsAsync<NotAuthorizedException>(() => user.ChangePasswordAsync("PassWord1!", "PassWord2!"));
         }
 
         // Tests that a CognitoUser object has a valid session object after being authenticated


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/129

*Description of changes:*
Fixed bug with StartWithSrpAuthAsync(InitiateSrpAuthRequest) that would result in a deadlock scenario if the method was called by a synchronous context (e.g. .Result called on the method).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
