### PR TITLE
Code improvements

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoDevice.cs
@@ -89,13 +89,12 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if (deviceKey == null)
             {
-                throw new ArgumentNullException("deviceKey", "deviceKey cannot be null.");
+                throw new ArgumentNullException(nameof(deviceKey));
             }
 
             if(deviceAttributes == null)
             {
-                throw new ArgumentNullException("deviceAttributes", "deviceAttributes cannot be null.");
-
+                throw new ArgumentNullException(nameof(deviceAttributes));
             }
 
             this.DeviceKey = deviceKey;
@@ -115,7 +114,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if (device == null)
             {
-                throw new ArgumentNullException("device", "Device cannot be null.");
+                throw new ArgumentNullException(nameof(device));
             }
 
             this.DeviceKey = device.DeviceKey;

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUser.cs
@@ -773,7 +773,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if (attributeNamesToDelete == null || attributeNamesToDelete.Count < 1)
             {
-                throw new ArgumentNullException("attributeNamesToDelete cannot be null or empty.", "attributeNamesToDelete");
+                throw new ArgumentNullException(nameof(attributeNamesToDelete), $"{nameof(attributeNamesToDelete)} cannot be null or empty.");
             }
 
             EnsureUserAuthenticated();
@@ -791,7 +791,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if (userSettings == null || userSettings.Count < 1)
             {
-                throw new ArgumentNullException("userSettings cannot be null or empty.", "userSettings");
+                throw new ArgumentNullException(nameof(userSettings), $"{nameof(userSettings)} cannot be null or empty.");
             }
 
             EnsureUserAuthenticated();

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -171,9 +171,9 @@ namespace Amazon.Extensions.CognitoAuthentication
             string salt = challenge.ChallengeParameters[CognitoConstants.ChlgParamSalt];
             BigInteger srpb = BigIntegerExtensions.FromUnsignedLittleEndianHex(challenge.ChallengeParameters[CognitoConstants.ChlgParamSrpB]);
 
-            if ((srpb.TrueMod(AuthenticationHelper.N)).Equals(BigInteger.Zero))
+            if (srpb.TrueMod(AuthenticationHelper.N).Equals(BigInteger.Zero))
             {
-                throw new ArgumentException("SRP error, B mod N cannot be zero.", "challenge");
+                throw new ArgumentException("SRP error, B mod N cannot be zero.", nameof(challenge));
             }
 
             string timeStr = DateTime.UtcNow.ToString("ddd MMM d HH:mm:ss \"UTC\" yyyy", CultureInfo.InvariantCulture);
@@ -504,8 +504,8 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Uses the properties of the RespondToNewPasswordRequiredRequest object to respond to the current new 
         /// password required authentication challenge using an asynchronous call
         /// </summary>
-        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
-        /// <param name="requiredAttributes">Optional dictionnary of attributes that may be required by the user pool
+        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary data</param>
+        /// <param name="requiredAttributes">Optional dictionary of attributes that may be required by the user pool
         /// Each attribute key must be prefixed by "userAttributes."
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <returns>Returns the AuthFlowResponse object that can be used to respond to the next challenge, 
@@ -519,8 +519,8 @@ namespace Amazon.Extensions.CognitoAuthentication
         /// Uses the properties of the RespondToNewPasswordRequiredRequest object to respond to the current new 
         /// password required authentication challenge using an asynchronous call
         /// </summary>
-        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary 
-        /// <param name="requiredAttributes">Optional dictionnary of attributes that may be required by the user pool
+        /// <param name="newPasswordRequest">RespondToNewPasswordRequiredRequest object containing the necessary data</param>
+        /// <param name="requiredAttributes">Optional dictionary of attributes that may be required by the user pool
         /// Each attribute key must be prefixed by "userAttributes."
         /// parameters to respond to the current SMS MFA authentication challenge</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
@@ -794,9 +794,9 @@ namespace Amazon.Extensions.CognitoAuthentication
             string salt = challenge.ChallengeParameters[CognitoConstants.ChlgParamSalt];
             BigInteger srpb = BigIntegerExtensions.FromUnsignedLittleEndianHex(challenge.ChallengeParameters[CognitoConstants.ChlgParamSrpB]);
 
-            if ((srpb.TrueMod(AuthenticationHelper.N)).Equals(BigInteger.Zero))
+            if (srpb.TrueMod(AuthenticationHelper.N).Equals(BigInteger.Zero))
             {
-                throw new ArgumentException("SRP error, B mod N cannot be zero.", "challenge");
+                throw new ArgumentException("SRP error, B mod N cannot be zero.", nameof(challenge));
             }
 
             DateTime timestamp = DateTime.UtcNow;

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserPool.cs
@@ -62,7 +62,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             if(!poolID.Contains("_"))
             {
-                throw new ArgumentException("PoolID should be of the form <region>_<poolname>.", "poolID");
+                throw new ArgumentException($"{nameof(poolID)} should be of the form <region>_<poolname>.", nameof(poolID));
             }
 
             this.PoolID = poolID;
@@ -133,7 +133,7 @@ namespace Amazon.Extensions.CognitoAuthentication
             }
             else
             {
-                throw new ArgumentNullException("userAttributes", "userAttributes cannot be null.");
+                throw new ArgumentNullException(nameof(userAttributes));
             }
 
             List<AttributeType> validationDataList = 
@@ -344,7 +344,7 @@ namespace Amazon.Extensions.CognitoAuthentication
             }
             else
             {
-                throw new ArgumentNullException(nameof(userAttributes), "userAttributes cannot be null.");
+                throw new ArgumentNullException(nameof(userAttributes));
             }
 
             List<AttributeType> validationDataList =
@@ -361,15 +361,15 @@ namespace Amazon.Extensions.CognitoAuthentication
         }
 
         /// <summary>
-        /// Resets the <paramref name="user"/>'s password to the specified <paramref name="newPassword"/> after
+        /// Resets the user's password to the specified <paramref name="newPassword"/> after
         /// validating the given password reset <paramref name="token"/>.
         /// </summary>
-        /// <param name="user">The user whose password should be reset.</param>
+        /// <param name="userID">The ID of user whose password should be reset.</param>
         /// <param name="token">The password reset token to verify.</param>
         /// <param name="newPassword">The new password to set if reset token verification succeeds.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation</param>
         /// <returns>
-        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
-        /// of the operation.
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="ConfirmForgotPasswordResponse"/>.
         /// </returns>
         public Task ConfirmForgotPassword(string userID, string token, string newPassword, CancellationToken cancellationToken)
         {

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/CognitoAuthHelper.cs
@@ -118,7 +118,7 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
         {
             if (hexString.Length % 2 != 0)
             {
-                throw new ArgumentException("Malformed hexString.", "hexString");
+                throw new ArgumentException("Malformed hexString.", nameof(hexString));
             }
 
             int stringLen = hexString.Length;


### PR DESCRIPTION
1. Replace parameter name as string to **nameof** usage, fix parameters order in several calls.
2. Remove redundant bracers at method calls.
3. Method comment: parameter name fix, add missing </param> tag, fix description for return type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
