### PR TITLE
Adding ClientMetadata to InitiateAuthRequest during StartWithSrpAuthAsync

### DIFF
--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -63,6 +63,11 @@ namespace Amazon.Extensions.CognitoAuthentication
             Tuple<BigInteger, BigInteger> tupleAa = AuthenticationHelper.CreateAaTuple();
             InitiateAuthRequest initiateRequest = CreateSrpAuthRequest(tupleAa);
 
+            if (srpRequest.ClientMetadata != null)
+            {
+                initiateRequest.ClientMetadata = new Dictionary<string, string>(srpRequest.ClientMetadata);
+            }
+
             if (srpRequest.IsCustomAuthFlow)
             {
                 initiateRequest.AuthFlow = AuthFlowType.CUSTOM_AUTH;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

ClientMetadata is set on InitiateAuthRequest if present in InitiateSrpAuthRequest. 

We use a pre-auth hook to do some captcha stuff in Cognito, we use ClientMetadata to send captcha values. 

Without this change ClientMetadata values are not send as expected. In other Client libraries (like React) this data is currently forwarded.

My pre-auth hook is now happy, but I suspect this may want a deeper look into where else these values are not added when they should be. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
