### PR TITLE
fix: Integration test started to fail because of missing condition block

### DIFF
--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/CognitoAWSCredentialsTests.cs
@@ -78,7 +78,8 @@ namespace CognitoAuthentication.IntegrationTests.NET45
                 RoleName = "_TestRole_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"),
                 AssumeRolePolicyDocument = "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect" +
                 "\": \"Allow\",\"Principal\": {\"Federated\": \"cognito-identity.amazonaws.com\"}," +
-                "\"Action\": \"sts:AssumeRoleWithWebIdentity\"}]}"
+                "\"Action\": \"sts:AssumeRoleWithWebIdentity\",\"Condition\": {\"StringEquals\": {" +
+                "\"cognito-identity.amazonaws.com:aud\": [\"" + identityPoolId + "\"]}}}]}"
             }).Result;
             roleName = roleResponse.Role.RoleName;
 


### PR DESCRIPTION
*Description of changes:*
* The Integration test `TestGetCognitoAWSCredentials` started to fail because of change in IAM which requires any role created or modified that targets Cognito to contain a condition block. This PR adds a condition block that references the created identity pool ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
