### PR TITLE
Fix integration test

### DIFF
--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/SessionTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Extensions.CognitoAuthentication.Util;
+using System.Linq;
 
 namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
 {
@@ -55,7 +56,7 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
                 }).ConfigureAwait(false);
             GetUserResponse userDetails = await user.GetUserDetailsAsync().ConfigureAwait(false);
 
-            Assert.True(string.Equals(userDetails.UserAttributes[2].Name, CognitoConstants.UserAttrEmail, StringComparison.Ordinal));
+            Assert.True(userDetails.UserAttributes.Any(x => string.Equals(x.Name, CognitoConstants.UserAttrEmail, StringComparison.Ordinal)));
             Assert.Empty(userDetails.MFAOptions);
         }
 


### PR DESCRIPTION
*Description of changes:*
Currently, The `TestGetUserDetails` asserts that the `UserAttributes` on index 2 matches an expected value but results in a test failure. I changed the condition so that it loops through different entries and looks for a match to the expected value.

**Note:** This test also failed without the UA changes made in this repo.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
