### PR TITLE
fix: include breaking change details in changelog (gh issue #200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release 2025-07-29
 
 ### Amazon.Extensions.CognitoAuthentication (3.1.1)
-* Fix Auth with device and device confirmation
+* **BREAKING CHANGE**: Fix Auth with device and device confirmation. The third parameter in `GenerateDeviceVerifier()` method has been renamed from `username` to `deviceKey`. Existing code will compile but fail at runtime - update calls to pass the device key instead of username.
 
 ## Release 2025-06-03
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/200

*Description of changes:*
Clarifies the breaking change in v3.1.1 by explicitly marking it as a BREAKING CHANGE and explaining the parameter rename in GenerateDeviceVerifier() method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
