### PR TITLE
fix user pools in tests not being cleaned up

### DIFF
--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationCreateUserTests.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Xunit;
@@ -27,24 +28,33 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
     {
         public AuthenticationCreateUserTests() : base()
         {
-            AdminCreateUserRequest createUserRequest = new AdminCreateUserRequest()
+            try
             {
-                TemporaryPassword = "PassWord1!",
-                Username = "User5",
-                UserAttributes = new List<AttributeType>()
+                AdminCreateUserRequest createUserRequest = new AdminCreateUserRequest()
                 {
-                    new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"},
-                },
-                ValidationData = new List<AttributeType>()
-                {
-                    new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"}
-                },
-                UserPoolId = pool.PoolID
-            };
+                    TemporaryPassword = "PassWord1!",
+                    Username = "User5",
+                    UserAttributes = new List<AttributeType>()
+                    {
+                        new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"},
+                    },
+                    ValidationData = new List<AttributeType>()
+                    {
+                        new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"}
+                    },
+                    UserPoolId = pool.PoolID
+                };
 
-            AdminCreateUserResponse createReponse = provider.AdminCreateUserAsync(createUserRequest).Result;
+                AdminCreateUserResponse createReponse = provider.AdminCreateUserAsync(createUserRequest).Result;
 
-            user = new CognitoUser("User5", pool.ClientID, pool, provider);
+                user = new CognitoUser("User5", pool.ClientID, pool, provider);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"AuthenticationCreateUserTests constructor failed: {ex.Message}");
+                Dispose(); // Clean up the user pool that was created in base constructor
+                throw;     // Re-throw so test still fails as expected
+            }
         }
 
         // Tests the sessionauthentication process with a NEW_PASSWORD_REQURIED flow

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationSignUpUserTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/AuthenticationSignUpUserTests.cs
@@ -27,23 +27,32 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
     {
         public AuthenticationSignUpUserTests() : base()
         {
-            SignUpRequest signUpRequest = new SignUpRequest()
+            try
             {
-                ClientId = pool.ClientID,
-                Password = "PassWord1!",
-                Username = "User5",
-                UserAttributes = new List<AttributeType>()
+                SignUpRequest signUpRequest = new SignUpRequest()
                 {
-                    new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"},
-                },
-                ValidationData = new List<AttributeType>()
-                {
-                   new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"}
-                }
-            };
+                    ClientId = pool.ClientID,
+                    Password = "PassWord1!",
+                    Username = "User5",
+                    UserAttributes = new List<AttributeType>()
+                    {
+                        new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"},
+                    },
+                    ValidationData = new List<AttributeType>()
+                    {
+                       new AttributeType() {Name=CognitoConstants.UserAttrEmail, Value="xxx@yyy.zzz"}
+                    }
+                };
 
-            SignUpResponse signUpResponse = provider.SignUpAsync(signUpRequest).Result;
-            user = new CognitoUser("User5", pool.ClientID, pool, provider);
+                SignUpResponse signUpResponse = provider.SignUpAsync(signUpRequest).Result;
+                user = new CognitoUser("User5", pool.ClientID, pool, provider);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"AuthenticationSignUpUserTests constructor failed: {ex.Message}");
+                Dispose(); // Clean up the user pool that was created in base constructor
+                throw;     // Re-throw so test still fails as expected
+            }
         }
 
         // Tests the SignUp method (using random, dummy email)

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/MfaAuthenticationTests.cs
@@ -61,14 +61,16 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
         /// </summary>
         public MfaAuthenticationTests()
         {
-            //Delete pool created by BaseAuthenticationTestClass
-            if(pool != null)
+            try
             {
-                provider.DeleteUserPoolAsync(new DeleteUserPoolRequest()
+                //Delete pool created by BaseAuthenticationTestClass
+                if(pool != null)
                 {
-                    UserPoolId = pool.PoolID
-                }).Wait();
-            }
+                    provider.DeleteUserPoolAsync(new DeleteUserPoolRequest()
+                    {
+                        UserPoolId = pool.PoolID
+                    }).Wait();
+                }
 
             UserPoolPolicyType passwordPolicy = new UserPoolPolicyType();
             List<SchemaAttributeType> requiredAttributes = new List<SchemaAttributeType>();
@@ -216,6 +218,13 @@ namespace Amazon.Extensions.CognitoAuthentication.IntegrationTests
             AdminConfirmSignUpResponse confirmResponse = provider.AdminConfirmSignUpAsync(confirmRequest).Result;
 
             this.user = new CognitoUser("User5", clientCreated.ClientId, pool, provider);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"MfaAuthenticationTests constructor failed: {ex.Message}");
+                Dispose(); // Clean up any resources that were created
+                throw;     // Re-throw so test still fails as expected
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We had some tests where the user pools were not being cleaned up because of failures in the constructor in the tests. When something in the constructor fails it doesnt call dispose. This change makes it so that if anything fails in the consructor we call dispose to cleanup the resources. 

I tested in my own account by running without the changes and verified nothing was cleanup when something fails in the constructor. i then ran the tests with my changes and everything was cleaned up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
