### PR TITLE
update dependencies

### DIFF
--- a/.autover/changes/9078b308-234e-4032-9d86-d180048e65d1.json
+++ b/.autover/changes/9078b308-234e-4032-9d86-d180048e65d1.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.CognitoAuthentication",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update package dependencies"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="4.0.2.4" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="4.0.4.2" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="4.0.2.14" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="4.0.4.12" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
+++ b/test/Amazon.Extensions.CognitoAuthentication.IntegrationTests/Amazon.Extensions.CognitoAuthentication.IntegrationTests.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.6" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.11.1" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="4.0.9.6" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.17.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/218

update deps to latest so they use a latest core version. i checked deps.json after making the update and can see a new version is used 

```
   "AWSSDK.Core/4.0.3.10": {
      "type": "package",
      "serviceable": true,
      "sha512": "sha512-PiGDGvWwHeZqbRVcUVrCs/sOjuMLqnH/VRWHe6yop8ZZG9LXuxL3GsfwbgatfzHuJsf1yhy2DuUu6rO3FulA5g==",
      "path": "awssdk.core/4.0.3.10",
      "hashPath": "awssdk.core.4.0.3.10.nupkg.sha512"
    },
```