### PR TITLE
Fix the issue with th-TH localization

### DIFF
--- a/.autover/changes/5b6ad383-558a-40b6-bd64-f503c4841394.json
+++ b/.autover/changes/5b6ad383-558a-40b6-bd64-f503c4841394.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.CognitoAuthentication",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix the method CognitoUser.GetCognitoAWSCredentials when the system localization is th-TH."
+      ]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ## Release 2025-07-29
 
 ### Amazon.Extensions.CognitoAuthentication (3.1.1)
-* Fix Auth with device and device confirmation
+* **BREAKING CHANGE**: Fix Auth with device and device confirmation. The third parameter in `GenerateDeviceVerifier()` method has been renamed from `username` to `deviceKey`. Existing code will compile but fail at runtime - update calls to pass the device key instead of username.
 
 ## Release 2025-06-03
 

--- a/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/CognitoUserAuthentication.cs
@@ -900,7 +900,7 @@ namespace Amazon.Extensions.CognitoAuthentication
         {
             EnsureUserAuthenticated();
 
-            string poolRegion = UserPool.PoolID.Substring(0, UserPool.PoolID.IndexOf("_"));
+            string poolRegion = UserPool.PoolID.Substring(0, UserPool.PoolID.IndexOf("_", StringComparison.InvariantCultureIgnoreCase));
             string providerName = "cognito-idp." + poolRegion + ".amazonaws.com/" + UserPool.PoolID;
 
             CognitoAWSCredentials credentials = new CognitoAWSCredentials(identityPoolID, identityPoolRegion);


### PR DESCRIPTION
Dotner runtime issues #100381 and #87939.

https://github.com/dotnet/runtime/issues/100381
https://github.com/dotnet/runtime/issues/87939

### Issue:
When user system localization is th-TH, the CognitoUser.GetCognitoAWSCredentials method does not work, even if the UserPool.PoolID configured properly.

### Fix
StringComparison parameter was added to the IndexOf method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
