### PR TITLE
Add xml documentation to NuGet package

### DIFF
--- a/.autover/changes/d55c1f4c-7af4-437d-9219-b24b4be11897.json
+++ b/.autover/changes/d55c1f4c-7af4-437d-9219-b24b4be11897.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.CognitoAuthentication",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add xml documentation to NuGet package"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
+++ b/src/Amazon.Extensions.CognitoAuthentication/Amazon.Extensions.CognitoAuthentication.csproj
@@ -21,6 +21,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
     <Version>3.1.4</Version>
   </PropertyGroup>
 

--- a/src/Amazon.Extensions.CognitoAuthentication/Util/AuthenticationHelper.cs
+++ b/src/Amazon.Extensions.CognitoAuthentication/Util/AuthenticationHelper.cs
@@ -76,7 +76,7 @@ namespace Amazon.Extensions.CognitoAuthentication.Util
         /// </summary>
         /// <param name="username"> Username of CognitoUser</param>
         /// <param name="password"> Password of CognitoUser</param>
-        /// <param name="poolName"> PoolName of CognitoUserPool (from poolID: <region>_<poolName>)</param>
+        /// <param name="poolName"> PoolName of CognitoUserPool (from poolID: region_poolName)</param>
         /// <param name="tupleAa"> TupleAa from CreateAaTuple</param>
         /// <param name="saltString"> salt provided in ChallengeParameters from Cognito </param>
         /// <param name="srpbString"> srpb provided in ChallengeParameters from Cognito</param>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net-extensions-cognito/issues/118

*Description of changes:*
The issue asked for PDB and the xml documentation into the NuGet package. The PDB files were taken care of awhile back when we added source link support. This takes care of making sure the xml doc is generated so it will be included in the package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
